### PR TITLE
update cpu_relax to new location

### DIFF
--- a/src/backoff.ml
+++ b/src/backoff.ml
@@ -10,7 +10,7 @@ let once (maxv, r) =
   if t = 0 then ()
   else begin
     for _ = 1 to 4096 * t do
-      Domain.Sync.cpu_relax ()
+      Domain.cpu_relax ()
     done
   end
 


### PR DESCRIPTION
This PR updates `Domain.Sync.cpu_relax` to its new location, so that lockfree compiles with ocaml trunk/5.00.