### PR TITLE
Remove unused dependencies from opam file

### DIFF
--- a/lockfree.opam
+++ b/lockfree.opam
@@ -9,8 +9,6 @@ dev-repo: "git+https://github.com/ocaml-multicore/lockfree.git"
 bug-reports: "https://github.com/ocaml-multicore/lockfree/issues"
 tags: []
 depends: [
-  "ocamlfind" {build}
-  "ocamlbuild" {build}
   "dune" {build}
 ]
 depopts: []

--- a/lockfree.opam
+++ b/lockfree.opam
@@ -11,8 +11,7 @@ tags: []
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "dune" {build} 
-	"kcas" {>= "0.1.3"}
+  "dune" {build}
 ]
 depopts: []
 build: [


### PR DESCRIPTION
I realized that kcas is not a dependency of lockfree following #5.
This PR thus removes it from the opam file.

Having a second look, ocamlfind and ocamlbuild are not required either,
so we might as well remove them to keep the dependencies minimal.