### PR TITLE
Stronger tests, and a couple optimizations in circular arrays.

### DIFF
--- a/seqtest/.gitignore
+++ b/seqtest/.gitignore
@@ -1,0 +1,3 @@
+input
+output
+dune-workspace.afl

--- a/seqtest/Makefile
+++ b/seqtest/Makefile
@@ -1,0 +1,3 @@
+SWITCH := 5.0.0+trunk
+EXE := seqtest.exe
+include $(shell ocamlfind query monolith)/Makefile.monolith

--- a/seqtest/Makefile
+++ b/seqtest/Makefile
@@ -1,3 +1,4 @@
-SWITCH := 5.0.0+trunk
+SWITCH := $(shell opam switch show)
 EXE := seqtest.exe
-include $(shell ocamlfind query monolith)/Makefile.monolith
+DUNEFLAGS := --profile seqtest
+include ./Makefile.monolith

--- a/seqtest/Makefile.monolith
+++ b/seqtest/Makefile.monolith
@@ -1,0 +1,364 @@
+# This Makefile is used by each of the demos.
+
+# Let's use a fixed shell.
+SHELL := bash
+
+# The following variables can be overridden via the command line or in a
+# Makefile that includes this Makefile.
+
+# The variable SWITCH must refer to a version of OCaml that has been
+# compiled with support for afl instrumentation.
+ifndef SWITCH
+  SWITCH := 4.11.1+afl
+endif
+
+# The variable SEED_SIZE determines the size (in bytes) of the random
+# data that we use as an initial input.
+ifndef SEED_SIZE
+  SEED_SIZE := 16
+endif
+
+# The variable EXE represents the path of the executable file that must
+# be tested relative to the current directory (the one where [make] is
+# run).
+ifndef EXE
+  EXE := Main.exe
+endif
+
+# The variable WHERE is the directory where the input/ and output/
+# subdirectories are created.
+ifndef WHERE
+  WHERE := .
+endif
+
+# dune options.
+ifndef DUNEFLAGS
+  DUNEFLAGS :=
+endif
+DUNEBUILD := dune build --no-print-directory --display quiet $(DUNEFLAGS)
+
+# The variable TIMEOUT_COMMAND specifies the name of the timeout command.
+# We wish to use GNU timeout. We assume that it must be named either
+# gtimeout or just timeout.
+TIMEOUT_COMMAND := $(shell \
+  if command -v gtimeout >/dev/null ; then echo gtimeout ; \
+  else echo timeout ; fi)
+
+# ----------------------------------------------------------------------------
+
+# Go up to the root of the dune project, and compute the location of the
+# build subdirectory that corresponds to the current directory.
+
+BUILD := $(shell \
+  up=""; down=""; switch="$(SWITCH)"; \
+  while ! [ -f dune-project ] ; do \
+    up="../"$$up ; down=/$$(basename $$(pwd))$$down ; \
+    cd .. ; \
+  done ; \
+  path=$$up"_build/"$${switch-default}$$down ; \
+  echo $$path \
+)
+
+# ----------------------------------------------------------------------------
+
+# [make all] compiles the code in an appropriate opam switch.
+
+.PHONY: all
+all:
+	@ $(DUNEBUILD) @check # build src/.merlin, etc.
+	@(echo "(lang dune 2.0)" && \
+	  echo "(context (opam (switch $(SWITCH))))" \
+	 ) > dune-workspace.afl
+	@ $(DUNEBUILD) --workspace dune-workspace.afl .
+
+# ----------------------------------------------------------------------------
+
+# [make setup] creates the required opam switch (if necessary) and installs
+# Monolith in it (if necessary).
+
+.PHONY: setup
+setup:
+	@ if opam switch list | grep '$(SWITCH) ' >/dev/null ; then \
+	  echo "The switch $(SWITCH) already exists." ; \
+	else \
+	  echo "Creating switch $(SWITCH)..." ; \
+	  opam switch create $(SWITCH) --no-switch ; \
+	fi ; \
+	echo "Installing monolith in the switch $(SWITCH)..." ; \
+	opam install --yes monolith --switch $(SWITCH)
+
+# ----------------------------------------------------------------------------
+
+# [make clean] cleans up.
+
+.PHONY: clean
+clean:
+	@ dune clean
+	@ rm -rf $(INPUT) $(OUTPUT) $(OUTPUT).*
+	@ rm -f dune-workspace.afl
+
+# ----------------------------------------------------------------------------
+
+# Settings.
+
+# Directories for input and output files.
+INPUT   := $(WHERE)/input
+OUTPUT  := $(WHERE)/output
+CRASHES := \
+  $(wildcard $(OUTPUT)/crashes/dummy) \
+  $(wildcard $(OUTPUT)/crashes/id*) \
+  $(wildcard $(OUTPUT)/*/crashes/id*) \
+
+# This is where dune places the executable file.
+BINARY  := $(BUILD)/$(EXE)
+
+# On MacOS, the highest stack size that seems permitted is 65532.
+STACK   := ulimit -s 65532
+
+# ----------------------------------------------------------------------------
+
+# [make prepare] makes preparations for running afl-fuzz.
+
+PATTERN  := /proc/sys/kernel/core_pattern
+GOVERNOR := /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+
+.PHONY: prepare
+prepare:
+	@ if [[ "$$OSTYPE" == "linux-gnu" ]]; then \
+	  if grep -v -w --quiet core $(PATTERN) || \
+	     grep -v -w --quiet performance $(GOVERNOR) ; then \
+	    echo "Disabling the crash reporter, and changing CPU settings" ; \
+	    echo "so as to maximize performance." ; \
+	    echo "(This uses sudo; you may be asked for your password.)" ; \
+	    sudo bash -c \
+	      'echo core >$(PATTERN) && \
+	       (echo performance | tee $(GOVERNOR) >/dev/null)' ; \
+	  fi \
+	fi
+	@ rm -rf $(INPUT) $(OUTPUT)
+	@ mkdir -p $(INPUT) $(OUTPUT)/crashes
+	@ dd if=/dev/urandom bs=$(SEED_SIZE) count=1 > $(INPUT)/dummy 2>/dev/null
+
+# ----------------------------------------------------------------------------
+
+# [make test] runs afl-fuzz.
+
+# afl-fuzz must be interrupted by Ctrl-C after it has found some crashes
+# (or after it has run long enough).
+
+# afl-fuzz refuses to run if the dummy input file $(INPUT)/dummy happens
+# to cause a crash right away. This is why we run $(BINARY) once before
+# attempting to launch afl-fuzz. If this initial run fails, then we copy
+# $(INPUT)/dummy to $(OUTPUT)/crashes, so as to let [make show] and
+# [make min] work normally.
+
+.PHONY: test
+test: all prepare
+	@ make test_nodep
+
+.PHONY: test_nodep
+test_nodep:
+	@ if $(BINARY) $(INPUT)/dummy ; then \
+	    $(STACK) && afl-fuzz -i $(INPUT) -o $(OUTPUT) $(BINARY) @@ ; \
+	  else \
+	    exitcode=$$? ; \
+	    cp $(INPUT)/dummy $(OUTPUT)/crashes ; \
+	    exit $$exitcode ; \
+	  fi
+
+# ----------------------------------------------------------------------------
+
+# [make random] runs random tests (without using afl-fuzz).
+
+# When no file name is given, $(BINARY) reads from /dev/urandom.
+
+# It runs in an infinite loop and saves the scenarios that it finds
+# in the directory output/crashes, in a human-readable form. There
+# is no need to use [make show] to decode them.
+
+.PHONY: random
+random: all prepare
+	@ make random_nodep
+
+.PHONY: random_nodep
+random_nodep:
+	@ $(BINARY)
+
+# ----------------------------------------------------------------------------
+
+# [make unattended] runs either [make test] or [make random], according to the
+# variable MODE, and interrupts it after a while (TIMEOUT).
+# It then checks that the outcome is as expected, i.e., some bugs were found,
+# or no bugs were found, depending on EXPECTING_BUGS (which should be defined
+# as 0 or 1).
+
+TIMEOUT        := 20
+EXPECTING_BUGS :=  0
+MODE           := test # or: random
+
+RED             = \033[0;31m
+NORMAL          = \033[0m
+
+.PHONY: unattended
+unattended: all prepare
+	@ echo "     $$(pwd)"
+	@ echo "     Running unattended for at most $(TIMEOUT) seconds..."
+	@ (($(TIMEOUT_COMMAND) --signal=INT $(TIMEOUT) make $(MODE)_nodep >/dev/null 2>&1) || true) \
+	    | grep -v "aborting" || true
+	@ crashes=`ls $(OUTPUT)/crashes | grep -v README | wc -l` && \
+	  if (( $$crashes > 0 )) ; then \
+	    if (( $(EXPECTING_BUGS) > 0 )) ; then \
+	      echo "[OK] Found $$crashes faults, great." ; \
+	    else \
+	      printf "$(RED)[KO] Found $$crashes faults, but none were expected!\n$(NORMAL)" ; \
+	      exit 1 ; \
+	    fi \
+	  else \
+	    if (( $(EXPECTING_BUGS) > 0 )) ; then \
+	      printf "$(RED)[KO] Found no faults in $(TIMEOUT) seconds, yet some were expected!\n$(NORMAL)" ; \
+	      exit 1 ; \
+	    else \
+	      echo "[OK] Found no faults, great." ; \
+	    fi \
+	  fi
+
+# ----------------------------------------------------------------------------
+
+# [make multicore] launches several instances of afl-fuzz in parallel.
+# Therefore, it is usually faster than [make test].
+
+# The following is a hopefully portable way of finding how many cores we have.
+
+CORES := $(shell \
+  nproc 2>/dev/null || \
+  sysctl -n hw.ncpu 2>/dev/null || \
+  getconf _NPROCESSORS_ONLN 2>/dev/null || \
+  echo 1)
+
+# Choose a heuristic number of slaves.
+
+SLAVES := $(shell expr $(CORES) - 1)
+
+.PHONY: check_enough_cores
+check_enough_cores:
+	@ echo "We have $(CORES) cores."
+	@ if [[ "$(SLAVES)" -le "0" ]]; then \
+	    echo "Not enough cores! Run 'make test' instead."; exit 1; fi
+
+.PHONY: multicore
+multicore: all prepare check_enough_cores
+# Run one instance in master mode, and many instances in slave mode.
+# The only difference between masters and slaves is that the master
+# performs additional deterministic checks.
+# All processes are launched in the background.
+	@ $(STACK) && \
+	echo "Launching $(SLAVES) slave instances..." ; \
+	for i in `seq $(SLAVES)` ; do \
+	  (afl-fuzz -i $(INPUT) -o $(OUTPUT) -S slave$$i $(BINARY) @@ >/dev/null &) ; \
+	done ; \
+	echo "Launching one master instance..." ; \
+	(afl-fuzz -i $(INPUT) -o $(OUTPUT) -M master $(BINARY) @@ >/dev/null &) ; \
+# In the foreground, provide periodic progress reports.
+	while true ; do afl-whatsup $(OUTPUT) ; sleep 3 ; done
+
+# [make tmux] runs in multicore mode and uses tmux to show all GUIs at
+# once in a terminal window. (A large window and a small font size are
+# needed.)
+
+# Repeating [tmux select-layout tiled] after every step seems required;
+# otherwise, tmux can refuse to split a window, arguing that there is
+# not enough space.
+
+.PHONY: tmux
+tmux: all prepare check_enough_cores
+	@ $(STACK) && \
+	tmux new-session -s monolith -d "afl-fuzz -i $(INPUT) -o $(OUTPUT) -S master $(BINARY) @@" ; \
+	tmux select-layout tiled ; \
+	for i in `seq $(SLAVES)` ; do \
+	  tmux split-window "afl-fuzz -i $(INPUT) -o $(OUTPUT) -S slave$$i $(BINARY) @@" ; \
+	  tmux select-layout tiled ; \
+	done ; \
+	tmux select-layout tiled ; \
+	tmux attach-session
+
+.PHONY: whatsup
+whatsup:
+	afl-whatsup $(OUTPUT)
+
+# ----------------------------------------------------------------------------
+
+# [make show] displays the problems found by afl-fuzz in the previous run.
+
+.PHONY: show
+show:
+	@ $(STACK) && \
+	  (for f in $(CRASHES) ; do \
+	    echo "(* $$f *)"; \
+	    tmp=`mktemp /tmp/crash.XXXX` && \
+	    ($(BINARY) $$f > $$tmp 2>&1 || true) >/dev/null 2>&1 ; \
+	    cat $$tmp ; \
+	    rm $$tmp ; \
+	    echo ; \
+	  done) | more
+
+# ----------------------------------------------------------------------------
+
+# [make summary] is like [make show], but postprocesses its output so as to
+# keep only the last instruction before the crash, and sorts these lines, so
+# as to determine the length of the shortest instruction sequence that causes
+# a problem.
+
+# If you determine that a crash can be obtained in (say) 4 instructions, then
+# typing [make show] and searching for "@04: Failure" will allow you to
+# inspect the scenario that caused this crash.
+
+.PHONY: summary
+summary:
+	@ $(STACK) && \
+	  parallel '$(BINARY) {} 2>/dev/null | grep "Failure" | head -n 1' ::: $(CRASHES) \
+	  | sort -r
+
+# ----------------------------------------------------------------------------
+
+# [make min] attempts to minimize the problematic inputs found by
+# afl-fuzz in the previous run.
+
+.PHONY: min
+min:
+	@ COPY=`mktemp -d $(OUTPUT).XXXX` && rm -rf $(COPY) && \
+	  echo "Saving un-minimized output to $$COPY." && \
+	  cp -rf $(OUTPUT) $$COPY
+	@ $(STACK) && \
+	  parallel 'afl-tmin -i {} -o {} -- $(BINARY) @@' ::: $(CRASHES)
+
+# ----------------------------------------------------------------------------
+
+# [make unload] turns off the MacOS Crash Reporter utility.
+# [make load] turns it on again.
+# This utility should be OFF for afl-fuzz to work correctly.
+
+SL := /System/Library
+PL := com.apple.ReportCrash
+
+.PHONY: unload
+unload:
+	launchctl unload -w $(SL)/LaunchAgents/$(PL).plist
+	sudo launchctl unload -w $(SL)/LaunchDaemons/$(PL).Root.plist
+
+.PHONY: load
+load:
+	launchctl load -w $(SL)/LaunchAgents/$(PL).plist
+	sudo launchctl load -w $(SL)/LaunchDaemons/$(PL).Root.plist
+
+# ----------------------------------------------------------------------------
+
+# [make switch] prints the value of SWITCH.
+
+.PHONY: switch
+switch:
+	@ echo $(SWITCH)
+
+# [make binary] prints the value of BINARY.
+.PHONY: binary
+binary:
+	@ echo $(BINARY)

--- a/seqtest/README.md
+++ b/seqtest/README.md
@@ -1,0 +1,11 @@
+## A sequential test of the work-stealing queue
+
+This test exercises the work-stealing queue in `Ws_deque`
+in a purely sequential mode.
+
+To compile this test, type `make` or `dune build`.
+
+To run this test, type `make random` or `dune exec ./seqtest.exe`.
+The test runs until it is interrupted.
+
+This test requires the `monolith` package.

--- a/seqtest/README.md
+++ b/seqtest/README.md
@@ -3,9 +3,11 @@
 This test exercises the work-stealing queue in `Ws_deque`
 in a purely sequential mode.
 
-To compile this test, type `make` or `dune build`.
+To compile this test, type `make` or `dune build --profile seqtest`.
 
-To run this test, type `make random` or `dune exec ./seqtest.exe`.
+To run this test, type `make random` or `dune exec --profile seqtest ./seqtest.exe`.
 The test runs until it is interrupted.
 
-This test requires the `monolith` package.
+This test requires the `monolith` package. Because we do not wish
+to create a hard dependency on `monolith`, the code in this directory
+is built by `dune` only when `--profile seqtest` is passed on the command line.

--- a/seqtest/dune
+++ b/seqtest/dune
@@ -1,0 +1,5 @@
+(executable
+  (name seqtest)
+  (libraries monolith lockfree)
+  (modules seqtest)
+)

--- a/seqtest/dune
+++ b/seqtest/dune
@@ -2,4 +2,5 @@
   (name seqtest)
   (libraries monolith lockfree)
   (modules seqtest)
+  (enabled_if (= %{profile} seqtest))
 )

--- a/seqtest/seqtest.ml
+++ b/seqtest/seqtest.ml
@@ -1,0 +1,100 @@
+open Monolith
+open Lockfree.Ws_deque
+
+(* This sequential implementation of stacks serves as a reference. *)
+
+(* For efficiency, we implement a bounded deque inside an array. *)
+
+(* [bound] is both the maximum size of the deque in the reference
+   implementation and the maximum length of the test scenarios that
+   we use. *)
+
+let bound =
+  1050
+
+module R (* Reference *) = struct
+
+  (* To avoid difficuties with initialization problem, we specialize
+     our deque: its elements are integers. This is good enough for
+     our purposes. *)
+
+  type deque = {
+    mutable top: int;
+    mutable bottom: int;
+    data: int array;
+  }
+
+  let default =
+    -1
+
+  let create () =
+    let top = 0
+    and bottom = 0
+    and data = Array.make bound default in
+    { top; bottom; data }
+
+  let push deque x =
+    (* The capacity of the array cannot be exceeded because our test
+       scenarios are sufficiently short. *)
+    assert (deque.bottom < bound);
+    deque.data.(deque.bottom) <- x;
+    deque.bottom <- deque.bottom + 1
+
+  let pop deque =
+    assert (deque.top <= deque.bottom);
+    if deque.top = deque.bottom then
+      raise Exit
+    else begin
+      deque.bottom <- deque.bottom - 1;
+      let x = deque.data.(deque.bottom) in
+      x
+    end
+
+  let steal deque =
+    assert (deque.top <= deque.bottom);
+    if deque.top = deque.bottom then
+      raise Exit
+    else begin
+      let x = deque.data.(deque.top) in
+      deque.top <- deque.top + 1;
+      x
+    end
+
+end
+
+(* The work-stealing queue is the candidate implementation. *)
+
+module C (* Candidate *) =
+  M
+
+(* Define [element] as an alias for the concrete type [int]. Equip it with a
+   deterministic generator of fresh elements. *)
+
+let element =
+  sequential()
+
+(* Declare an abstract type [stack]. *)
+
+let stack =
+  declare_abstract_type ()
+
+(* Declare the operations. *)
+
+let () =
+  let spec = unit ^> stack in
+  declare "create" spec R.create C.create;
+
+  let spec = stack ^> element ^> unit in
+  declare "push" spec R.push C.push;
+
+  let spec = stack ^!> element in
+  declare "pop" spec R.pop C.pop;
+
+  let spec = stack ^!> element in
+  declare "steal" spec R.steal C.steal
+
+(* Start the engine! *)
+
+let () =
+  let fuel = bound in
+  main fuel

--- a/src/ArrayExtra.ml
+++ b/src/ArrayExtra.ml
@@ -1,0 +1,53 @@
+(* The following code is taken from the library [sek] by Arthur Charguéraud
+   and François Pottier. *)
+
+(** [blit_circularly_dst a1 i1 a2 i2 k] copies [k] elements from the array
+    [a1], starting at index [i1], to the array [a2], starting at index [i2].
+    The destination array is regarded as circular, so it is permitted for the
+    destination range to wrap around. *)
+let blit_circularly_dst a1 i1 a2 i2 k =
+  (* The source range must be well-formed. *)
+  assert (0 <= k && 0 <= i1 && i1 + k <= Array.length a1);
+  (* The destination array must be large enough to hold the data. *)
+  let n2 = Array.length a2 in
+  assert (k <= n2);
+  (* The destination index must be well-formed. *)
+  assert (0 <= i2 && i2 < n2);
+  (* We need either one or two blits. *)
+  if i2 + k <= n2 then
+    Array.blit a1 i1 a2 i2 k
+  else begin
+    let k1 = n2 - i2 in
+    assert (0 < k1 && k1 < k);
+    Array.blit a1 i1 a2 i2 k1;
+    Array.blit a1 (i1 + k1) a2 0 (k - k1)
+  end
+
+(** [blit_circularly a1 i1 a2 i2 k] copies [k] elements from the array [a1],
+    starting at index [i1], to the array [a2], starting at index [i2]. Both
+    the source array and the destination array are regarded as circular, so
+    it is permitted for the source range or destination range to wrap around.
+    [i1] must be comprised between 0 included and [Array.length a1] excluded.
+    [i2] must be comprised between 0 included and [Array.length a2] excluded.
+    [k] must be comprised between 0 included and [Array.length a2] included. *)
+let blit_circularly a1 i1 a2 i2 k =
+  let n1 = Array.length a1 in
+  (* The source range must be well-formed. *)
+  assert (0 <= i1 && i1 < n1);
+  assert (0 <= k);
+  (* The destination array must be large enough to hold the data. *)
+  let n2 = Array.length a2 in
+  assert (k <= n2);
+  (* The destination index must be well-formed. *)
+  assert (0 <= i2 && i2 < n2);
+  (* We need either one or two calls to [blit_circularly_dst]. *)
+  if i1 + k <= n1 then
+    blit_circularly_dst a1 i1 a2 i2 k
+  else begin
+    let k1 = n1 - i1 in
+    assert (0 < k1 && k1 < k);
+    blit_circularly_dst a1 i1 a2 i2 k1;
+    let i2 = i2 + k1 in
+    let i2 = if i2 < n2 then i2 else i2 - n2 in
+    blit_circularly_dst a1 0 a2 i2 (k - k1)
+  end

--- a/src/ws_deque.ml
+++ b/src/ws_deque.ml
@@ -66,23 +66,29 @@ module CArray = struct
   let put t i v =
     Array.unsafe_set t (index i t) v [@@inline]
 
+  let transfer src dst top num =
+    ArrayExtra.blit_circularly
+      (* source array and index: *)
+      src (index top src)
+      (* target array and index: *)
+      dst (index top dst)
+      (* number of elements: *)
+      num
+    [@@inline]
+
   let grow t top bottom =
-    let s = size t in
-    let ns = 2 * s in
-    let out = create ns (Obj.magic ()) in
-    for i = top to bottom do
-      put out i (get t i)
-    done;
-    out
+    let sz = size t in
+    assert (bottom - top = sz);
+    let dst = create (2 * sz) (Obj.magic ()) in
+    transfer t dst top sz;
+    dst
 
   let shrink t top bottom =
-    let s = size t in
-    let ns = s / 2 in
-    let out = create ns (Obj.magic ()) in
-    for i = top to bottom do
-      put out i (get t i)
-    done;
-    out
+    let sz = size t in
+    assert (bottom - top <= sz / 2);
+    let dst = create (sz / 2) (Obj.magic ()) in
+    transfer t dst top (bottom - top);
+    dst
 
 end
 

--- a/src/ws_deque.ml
+++ b/src/ws_deque.ml
@@ -37,10 +37,8 @@ end
 
 module CArray = struct
 
-  type 'a t = {
-    arr  : 'a array;
-    mask : int
-    }
+  type 'a t =
+    'a array
 
   let rec log2 n =
     if n <= 1 then 0 else 1 + (log2 (n asr 1))
@@ -49,18 +47,24 @@ module CArray = struct
     (* [sz] must be a power of two. *)
     assert (0 < sz && sz = Int.shift_left 1 (log2 sz));
     assert (Int.logand sz (sz-1) == 0);
-    {
-      arr  = Array.make sz v;
-      mask = sz - 1
-    }
+    Array.make sz v
 
-  let size t = Array.length t.arr [@@inline]
+  let size t =
+    Array.length t [@@inline]
+
+  let mask t =
+    size t - 1 [@@inline]
+
+  let index i t =
+    (* Because [size t] is a power of two, [i mod (size t)] is the same as
+       [i land (size t - 1)], that is, [i land (mask t)]. *)
+    Int.logand i (mask t) [@@inline]
 
   let get t i =
-    Array.unsafe_get t.arr (Int.logand i t.mask) [@@inline]
+    Array.unsafe_get t (index i t) [@@inline]
 
   let put t i v =
-    Array.unsafe_set t.arr (Int.logand i t.mask) v [@@inline]
+    Array.unsafe_set t (index i t) v [@@inline]
 
   let grow t top bottom =
     let s = size t in

--- a/src/ws_deque.ml
+++ b/src/ws_deque.ml
@@ -45,9 +45,9 @@ module CArray = struct
   let rec log2 n =
     if n <= 1 then 0 else 1 + (log2 (n asr 1))
 
-  let create n v =
-    let sz = Int.shift_left 1 (log2 n) in
-    assert ((sz >= n) && (sz > 0));
+  let create sz v =
+    (* [sz] must be a power of two. *)
+    assert (0 < sz && sz = Int.shift_left 1 (log2 sz));
     assert (Int.logand sz (sz-1) == 0);
     {
       arr  = Array.make sz v;

--- a/test/test_ws_deque.ml
+++ b/test/test_ws_deque.ml
@@ -4,12 +4,11 @@ module Ws_deque = Ws_deque.M
 
 let test_empty () =
   let q = Ws_deque.create () in
-  let r = try
-            Ws_deque.pop q
-          with Exit -> - 1
-  in
-  assert (r = -1);
-  print_string "test_exit: ok\n"
+  match Ws_deque.pop q with
+  | exception Exit ->
+      print_string "test_exit: ok\n"
+  | _ ->
+      assert false
 
 let test_push_and_pop () =
   let q = Ws_deque.create () in

--- a/test/test_ws_deque.ml
+++ b/test/test_ws_deque.ml
@@ -1,33 +1,32 @@
 (** Tests *)
-open Lockfree
-module Ws_deque = Ws_deque.M
+open Lockfree.Ws_deque.M
 
 let test_empty () =
-  let q = Ws_deque.create () in
-  match Ws_deque.pop q with
+  let q = create () in
+  match pop q with
   | exception Exit ->
       print_string "test_exit: ok\n"
   | _ ->
       assert false
 
 let test_push_and_pop () =
-  let q = Ws_deque.create () in
-  Ws_deque.push q 1;
-  Ws_deque.push q 10;
-  Ws_deque.push q 100;
-  assert (Ws_deque.pop q = 100);
-  assert (Ws_deque.pop q = 10);
-  assert (Ws_deque.pop q = 1);
+  let q = create () in
+  push q 1;
+  push q 10;
+  push q 100;
+  assert (pop q = 100);
+  assert (pop q = 10);
+  assert (pop q = 1);
   print_string "test_push_and_pop: ok\n"
 
 let test_push_and_steal () =
-  let q = Ws_deque.create () in
-  Ws_deque.push q 1;
-  Ws_deque.push q 10;
-  Ws_deque.push q 100;
+  let q = create () in
+  push q 1;
+  push q 10;
+  push q 100;
   let domains = Array.init 3 (fun _ ->
     Domain.spawn (fun _ -> let v =
-      Ws_deque.steal q in assert (v = 1 || v = 10 || v = 100))) in
+      steal q in assert (v = 1 || v = 10 || v = 100))) in
   Array.iter Domain.join domains;
   print_string "test_push_and_steal: ok\n"
 


### PR DESCRIPTION
This PR proposes:
* A reasonably strong sequential test: `make -C seqtest random`. (Requires `monolith`.)
* A reasonably strong concurrent test: `dune runtest --force`.
* An optimization in circular arrays: remove the redundant `mask` field and remove an indirection.
* An optimization in circular arrays: use `Array.blit` instead of a loop when growing or shrinking.
