### PR TITLE
Add single-producer single-consumer queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 A collection of Concurrent Lockfree Data Structures for OCaml 5. It contains:
 
 * [Chase-Lev Work-Stealing Queue](src/ws_deque.mli)
+* [SPSC Queue](src/spsc_queue.mli) Simple single-producer single-consumer fixed-size queue. Thread-safe as long as at most one thread acts as producer and at most one as consumer at any single point in time. 
 
 ## Usage
 

--- a/src/lockfree.ml
+++ b/src/lockfree.ml
@@ -27,3 +27,4 @@ Copyright (c) 2017, Nicolas ASSOUAD <nicolas.assouad@ens.fr>
 *)
 
 module Ws_deque = Ws_deque
+module Spsc_queue = Spsc_queue

--- a/src/lockfree.mli
+++ b/src/lockfree.mli
@@ -31,3 +31,4 @@ Copyright (c) 2017, Nicolas ASSOUAD <nicolas.assouad@ens.fr>
 *)
 
 module Ws_deque = Ws_deque
+module Spsc_queue = Spsc_queue

--- a/src/spsc_queue.ml
+++ b/src/spsc_queue.ml
@@ -1,45 +1,64 @@
+(*
+ * Copyright (c) 2022, Bartosz Modelski
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(* Single producer single consumer queue
+ *
+ * The algorithms here are inspired by:
+
+ * https://dl.acm.org/doi/pdf/10.1145/3437801.3441583
+ *)
+
 type 'a t = {
   array : 'a Option.t Array.t;
   tail : int Atomic.t;
   head : int Atomic.t;
-  mask : int
+  mask : int;
 }
+
+exception Full
 
 let create ~size_exponent =
   let size = Int.shift_left 1 size_exponent in
-  { head = Atomic.make 0;
+  {
+    head = Atomic.make 0;
     tail = Atomic.make 0;
     mask = size - 1;
-    array = Array.init size (fun _ -> None)
-  };;
+    array = Array.init size (fun _ -> None);
+  }
 
-let enqueue {array; head; tail; mask; _ } element =
+let push { array; head; tail; mask; _ } element =
   let size = mask + 1 in
-  let head_val = Atomic.get head in 
-  let tail_val = Atomic.get tail in 
-  if head_val + size == tail_val
-  then false 
+  let head_val = Atomic.get head in
+  let tail_val = Atomic.get tail in
+  if head_val + size == tail_val then raise Full
   else (
-    Array.set array (tail_val land mask) (Some element); 
-    Atomic.set tail (tail_val + 1);
-    true)
-;;
+    Array.set array (tail_val land mask) (Some element);
+    Atomic.set tail (tail_val + 1))
 
-let dequeue {array; head; tail; mask; _} =
-  let head_val = Atomic.get head in 
-  let tail_val = Atomic.get tail in 
-  if head_val == tail_val
-  then None
-  else (
-    let index = head_val land mask in 
+let pop { array; head; tail; mask; _ } =
+  let head_val = Atomic.get head in
+  let tail_val = Atomic.get tail in
+  if head_val == tail_val then None
+  else
+    let index = head_val land mask in
     let v = Array.get array index in
     (* allow gc to collect it *)
-    Array.set array index None;  
+    Array.set array index None;
     Atomic.set head (head_val + 1);
     assert (Option.is_some v);
-    v)
-;;
+    v
 
-let size {head; tail; _} = 
-  (Atomic.get tail) - (Atomic.get head)
-;;
+let size { head; tail; _ } = Atomic.get tail - Atomic.get head

--- a/src/spsc_queue.ml
+++ b/src/spsc_queue.ml
@@ -1,0 +1,45 @@
+type 'a t = {
+  array : 'a Option.t Array.t;
+  tail : int Atomic.t;
+  head : int Atomic.t;
+  mask : int
+}
+
+let create ~size_exponent =
+  let size = Int.shift_left 1 size_exponent in
+  { head = Atomic.make 0;
+    tail = Atomic.make 0;
+    mask = size - 1;
+    array = Array.init size (fun _ -> None)
+  };;
+
+let enqueue {array; head; tail; mask; _ } element =
+  let size = mask + 1 in
+  let head_val = Atomic.get head in 
+  let tail_val = Atomic.get tail in 
+  if head_val + size == tail_val
+  then false 
+  else (
+    Array.set array (tail_val land mask) (Some element); 
+    Atomic.set tail (tail_val + 1);
+    true)
+;;
+
+let dequeue {array; head; tail; mask; _} =
+  let head_val = Atomic.get head in 
+  let tail_val = Atomic.get tail in 
+  if head_val == tail_val
+  then None
+  else (
+    let index = head_val land mask in 
+    let v = Array.get array index in
+    (* allow gc to collect it *)
+    Array.set array index None;  
+    Atomic.set head (head_val + 1);
+    assert (Option.is_some v);
+    v)
+;;
+
+let size {head; tail; _} = 
+  (Atomic.get tail) - (Atomic.get head)
+;;

--- a/src/spsc_queue.mli
+++ b/src/spsc_queue.mli
@@ -1,0 +1,19 @@
+type 'a t 
+
+(* [create] initializes a single-producer single-consumer thread-safe queue. *)
+val create : size_exponent:int -> 'a t
+
+(* [enqueue] insert element into the queue. This method can be used by at most 1 
+  thread at the time. *)
+val enqueue : 'a t -> 'a -> bool 
+
+
+(* [dequeue] removes element from the queue, if any. This method can be used by 
+  at most 1 thread at the time. *)
+val dequeue : 'a t -> 'a option
+
+(* [size] returns the size of the queue. This method linearizes only when called 
+  from either enqueuer or dequeuer thread. Otherwise, it is safe to call but 
+  provides only an *indication* of the size of the structure. 
+*)
+val size : 'a t -> int

--- a/src/spsc_queue.mli
+++ b/src/spsc_queue.mli
@@ -1,19 +1,21 @@
-type 'a t 
+type 'a t
+(** Type of single-producer single-consumer non-resizable thread-safe
+   queue that works in FIFO order. *)
 
-(* [create] initializes a single-producer single-consumer thread-safe queue. *)
+exception Full
+
 val create : size_exponent:int -> 'a t
+(** [create ~size_exponent:int] creates a empty queue of size
+   [2^size_exponent].  *)
 
-(* [enqueue] insert element into the queue. This method can be used by at most 1 
-  thread at the time. *)
-val enqueue : 'a t -> 'a -> bool 
+val push : 'a t -> 'a -> unit
+(** [push q v] pushes [v] at the back of the queue. *)
 
-
-(* [dequeue] removes element from the queue, if any. This method can be used by 
+val pop : 'a t -> 'a option
+(** [pop q] removes element from head of the queue, if any. This method can be used by
   at most 1 thread at the time. *)
-val dequeue : 'a t -> 'a option
 
-(* [size] returns the size of the queue. This method linearizes only when called 
-  from either enqueuer or dequeuer thread. Otherwise, it is safe to call but 
-  provides only an *indication* of the size of the structure. 
-*)
 val size : 'a t -> int
+(** [size] returns the size of the queue. This method linearizes only when called
+  from either enqueuer or dequeuer thread. Otherwise, it is safe to call but
+  provides only an *indication* of the size of the structure. *)

--- a/test/dune
+++ b/test/dune
@@ -7,3 +7,8 @@
  (name test_spsc_queue)
  (libraries lockfree)
  (modules test_spsc_queue))
+
+(test
+ (name qcheck_spsc_queue)
+ (libraries lockfree qcheck qcheck-alcotest)
+ (modules qcheck_spsc_queue))

--- a/test/dune
+++ b/test/dune
@@ -2,3 +2,8 @@
  (name test_ws_deque)
  (libraries lockfree)
  (modules test_ws_deque))
+
+(test
+ (name test_spsc_queue)
+ (libraries lockfree)
+ (modules test_spsc_queue))

--- a/test/qcheck_spsc_queue.ml
+++ b/test/qcheck_spsc_queue.ml
@@ -1,0 +1,123 @@
+module Spsc_queue = Lockfree.Spsc_queue
+
+let keep_some l = List.filter Option.is_some l |> List.map Option.get
+let keep_n_first n = List.filteri (fun i _ -> i < n)
+
+let pop_n_times q n =
+  let rec loop count acc =
+    if count = 0 then acc
+    else
+      let v = Spsc_queue.pop q in
+      Domain.cpu_relax ();
+      loop (count - 1) (v :: acc)
+  in
+  loop n [] |> List.rev
+
+let tests =
+  [
+    (* TEST 1 - one producer, one consumer:
+       Sequential pushes then pops. Checks that the behaviour is similar to
+       one of a FIFO queue. *)
+    QCheck.(
+      Test.make ~name:"seq_pop_push"
+        (pair (list int) small_nat)
+        (fun (l, npop) ->
+          (* Making sure we do not create a too big queue. Other
+             tests are checking the behaviour of a full queue.*)
+          let size_exponent = 8 in
+          let size_max = Int.shift_left 1 size_exponent in
+          assume (List.length l < size_max);
+
+          (* Initialization *)
+          let q = Spsc_queue.create ~size_exponent in
+
+          (* Sequential pushed : not Full exception should be
+             raised. *)
+          let not_full_queue =
+            try
+              List.iter (Spsc_queue.push q) l;
+              true
+            with Spsc_queue.Full -> false
+          in
+
+          (* Consumer domain pops *)
+          let consumer = Domain.spawn (fun () -> pop_n_times q npop) in
+          let pops = Domain.join consumer in
+
+          (* Property *)
+          not_full_queue
+          && List.length pops = npop
+          && keep_some pops = keep_n_first (min (List.length l) npop) l));
+    (* TEST 2 - one producer, one consumer:
+       Parallel pushes and pops. Checks that the behaviour is similar to
+       one of a FIFO queue. *)
+    QCheck.(
+      Test.make ~name:"par_pop_push"
+        (pair (pair (list int) (list int)) small_nat)
+        (fun ((l, l'), npop) ->
+          (* Making sure we do not create a too big queue. Other
+               tests are checking the behaviour of a full queue.*)
+          let size_exponent = 8 in
+          let size_max = Int.shift_left 1 size_exponent in
+          assume (List.length l + List.length l' < size_max);
+
+          (* Initialization *)
+          let q = Spsc_queue.create ~size_exponent in
+          List.iter (Spsc_queue.push q) l;
+
+          (* Consumer pops *)
+          let sema = Semaphore.Binary.make false in
+          let consumer =
+            Domain.spawn (fun () ->
+                Semaphore.Binary.release sema;
+                pop_n_times q npop)
+          in
+
+          let producer =
+            Domain.spawn (fun () ->
+                (* Making sure the consumer can start *)
+                while not (Semaphore.Binary.try_acquire sema) do
+                  Domain.cpu_relax ()
+                done;
+                (* Main domain pushes.*)
+                List.iter
+                  (fun elt ->
+                    Spsc_queue.push q elt;
+                    Domain.cpu_relax ())
+                  l')
+          in
+
+          let popped = Domain.join consumer in
+          let _ = Domain.join producer in
+          let popped_val = popped |> keep_some in
+
+          (* Property *)
+          List.length popped = npop
+          && popped_val = keep_n_first (List.length popped_val) (l @ l')));
+    (* TEST 3 - one producer, one consumer:
+       Checks that pushing to much raise exception Full. *)
+    QCheck.(
+      Test.make ~name:"push_full" (list int) (fun l ->
+          let size_exponent = 4 in
+          let size_max = Int.shift_left 1 size_exponent in
+
+          (* Initialization *)
+          let q = Spsc_queue.create ~size_exponent in
+          let is_full =
+            try
+              List.iter (Spsc_queue.push q) l;
+              false
+            with Spsc_queue.Full -> true
+          in
+
+          (* Property *)
+          (List.length l > size_max && is_full)
+          || (List.length l <= size_max && not is_full)));
+  ]
+
+let main () =
+  let to_alcotest = List.map QCheck_alcotest.to_alcotest in
+  Alcotest.run "Spsc_queue" [ ("spsc_queue", to_alcotest tests) ]
+;;
+
+main ()

--- a/test/test_spsc_queue.ml
+++ b/test/test_spsc_queue.ml
@@ -3,43 +3,43 @@ open Lockfree
 
 let test_empty () =
   let q = Spsc_queue.create ~size_exponent:3 in
-  assert (Option.is_none (Spsc_queue.dequeue q)); 
+  assert (Option.is_none (Spsc_queue.pop q));
   assert (Spsc_queue.size q == 0);
   print_string "test_spsc_queue_empty: ok\n"
 ;;
 
+let push_not_full q elt =
+  try Spsc_queue.push q elt; true
+  with Spsc_queue.Full -> false
 
 let test_full () =
   let q = Spsc_queue.create ~size_exponent:3 in
-  for _ = 1 to 8 do 
-    assert (Spsc_queue.enqueue q ()); 
-  done;
-  assert (not (Spsc_queue.enqueue q ())); 
+  while (push_not_full q ()) do () done;
   assert (Spsc_queue.size q == 8);
   print_string "test_spsc_queue_full: ok\n";
 ;;
 
 
 let test_parallel () =
-  let count = 100_000 in 
+  let count = 100_000 in
   let q = Spsc_queue.create ~size_exponent:2 in
   (* producer *)
-  let producer = 
-    Domain.spawn (fun () -> 
-    for i = 1 to count do 
-      while not (Spsc_queue.enqueue q i) do () done;
+  let producer =
+    Domain.spawn (fun () ->
+    for i = 1 to count do
+      while not (push_not_full q i) do () done;
     done)
   in
   (* consumer *)
-  let last_num = ref 0 in 
-  while !last_num < count do 
-    match Spsc_queue.dequeue q with 
-    | None -> () 
-    | Some v -> 
+  let last_num = ref 0 in
+  while !last_num < count do
+    match Spsc_queue.pop q with
+    | None -> ()
+    | Some v ->
       (assert (v == !last_num + 1);
       last_num := v)
   done;
-  assert (Option.is_none (Spsc_queue.dequeue q));
+  assert (Option.is_none (Spsc_queue.pop q));
   assert (Spsc_queue.size q == 0);
   Domain.join producer;
   Printf.printf "test_spsc_queue_parallel: ok (transferred = %d)\n" !last_num;;

--- a/test/test_spsc_queue.ml
+++ b/test/test_spsc_queue.ml
@@ -1,0 +1,51 @@
+(** Tests *)
+open Lockfree
+
+let test_empty () =
+  let q = Spsc_queue.create ~size_exponent:3 in
+  assert (Option.is_none (Spsc_queue.dequeue q)); 
+  assert (Spsc_queue.size q == 0);
+  print_string "test_spsc_queue_empty: ok\n"
+;;
+
+
+let test_full () =
+  let q = Spsc_queue.create ~size_exponent:3 in
+  for _ = 1 to 8 do 
+    assert (Spsc_queue.enqueue q ()); 
+  done;
+  assert (not (Spsc_queue.enqueue q ())); 
+  assert (Spsc_queue.size q == 8);
+  print_string "test_spsc_queue_full: ok\n";
+;;
+
+
+let test_parallel () =
+  let count = 100_000 in 
+  let q = Spsc_queue.create ~size_exponent:2 in
+  (* producer *)
+  let producer = 
+    Domain.spawn (fun () -> 
+    for i = 1 to count do 
+      while not (Spsc_queue.enqueue q i) do () done;
+    done)
+  in
+  (* consumer *)
+  let last_num = ref 0 in 
+  while !last_num < count do 
+    match Spsc_queue.dequeue q with 
+    | None -> () 
+    | Some v -> 
+      (assert (v == !last_num + 1);
+      last_num := v)
+  done;
+  assert (Option.is_none (Spsc_queue.dequeue q));
+  assert (Spsc_queue.size q == 0);
+  Domain.join producer;
+  Printf.printf "test_spsc_queue_parallel: ok (transferred = %d)\n" !last_num;;
+
+
+let _ =
+  test_empty ();
+  test_full ();
+  test_parallel ();;

--- a/test/test_spsc_queue.ml
+++ b/test/test_spsc_queue.ml
@@ -1,24 +1,25 @@
-(** Tests *)
 open Lockfree
+(** Tests *)
 
 let test_empty () =
   let q = Spsc_queue.create ~size_exponent:3 in
   assert (Option.is_none (Spsc_queue.pop q));
   assert (Spsc_queue.size q == 0);
   print_string "test_spsc_queue_empty: ok\n"
-;;
 
 let push_not_full q elt =
-  try Spsc_queue.push q elt; true
+  try
+    Spsc_queue.push q elt;
+    true
   with Spsc_queue.Full -> false
 
 let test_full () =
   let q = Spsc_queue.create ~size_exponent:3 in
-  while (push_not_full q ()) do () done;
+  while push_not_full q () do
+    ()
+  done;
   assert (Spsc_queue.size q == 8);
-  print_string "test_spsc_queue_full: ok\n";
-;;
-
+  print_string "test_spsc_queue_full: ok\n"
 
 let test_parallel () =
   let count = 100_000 in
@@ -26,9 +27,11 @@ let test_parallel () =
   (* producer *)
   let producer =
     Domain.spawn (fun () ->
-    for i = 1 to count do
-      while not (push_not_full q i) do () done;
-    done)
+        for i = 1 to count do
+          while not (push_not_full q i) do
+            ()
+          done
+        done)
   in
   (* consumer *)
   let last_num = ref 0 in
@@ -36,16 +39,15 @@ let test_parallel () =
     match Spsc_queue.pop q with
     | None -> ()
     | Some v ->
-      (assert (v == !last_num + 1);
-      last_num := v)
+        assert (v == !last_num + 1);
+        last_num := v
   done;
   assert (Option.is_none (Spsc_queue.pop q));
   assert (Spsc_queue.size q == 0);
   Domain.join producer;
-  Printf.printf "test_spsc_queue_parallel: ok (transferred = %d)\n" !last_num;;
-
+  Printf.printf "test_spsc_queue_parallel: ok (transferred = %d)\n" !last_num
 
 let _ =
   test_empty ();
   test_full ();
-  test_parallel ();;
+  test_parallel ()


### PR DESCRIPTION
I have a few lock-free structures to donate (spsc queue, mpmc queue, multi-queue, spmc queue, spmc stack). Starting with the simplest one - single-producer single-consumer queue. 

### Structure

Enqueue inserts element into the structure, while dequeue removes in FIFO order. The structure is safe because, from the perspective of other operation, enqueuer operates only on [tail, head + size) part of the array, whereas dequeuer on [head, tail). Sample state:
```
| Index          | 0    | 1      | 2      | 3    |
| -------------- | ---- | ------ | ------ | ---- |
| Array (sz = 4) | None | Some A | Some B | None |
| Head           |      | X      |        |      |
| Tail           |      |        |        | X    |
| Enq. range     | X    |        |        | X    |
| Deq. range     |      | X      | X      |      |
```
### Testing

I've created a few simple tests, one with two threads and 100k items being transferred. I'd be happy to write some DSCheck tests (https://github.com/sadiqj/dscheck).

### Possible extensions: 
* Automatic resizing is a little awkward but possible. Natural place to grow the array would be in the insertion function. However, enqueuer cannot remove elements from the existing array in SPSC, so I guess we'd be end up with some sort of list of arrays. 
* Aligning the indices with cache lines significantly improves the performance (see https://github.com/anmolsahoo25/aligned_int).