### PR TITLE
Current Bench Setup 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all clean test bench
+
+all:
+	dune build
+
+test:
+	dune runtest
+
+clean:
+	dune clean
+
+bench:
+	@dune exec -- ./bench/main.exe --json

--- a/bench/bench_spsc_queue.ml
+++ b/bench/bench_spsc_queue.ml
@@ -1,0 +1,61 @@
+open Lockfree
+
+let item_count = 2_000_000
+
+let rec try_until_success f =
+  try f () with Spsc_queue.Full -> try_until_success f
+
+let run () =
+  let queue = Spsc_queue.create ~size_exponent:3 in
+  let pusher =
+    Domain.spawn (fun () ->
+        let start_time = Unix.gettimeofday () in
+        for i = 1 to item_count do
+          try_until_success (fun () -> Spsc_queue.push queue i)
+        done;
+        start_time)
+  in
+  for _ = 1 to item_count do
+    while Option.is_none (Spsc_queue.pop queue) do
+      ()
+    done
+  done;
+  let end_time = Unix.gettimeofday () in
+  let start_time = Domain.join pusher in
+  let time_diff = end_time -. start_time in
+  time_diff
+
+let create_output median_time median_throughput =
+  let time =
+    ({
+       name = "time";
+       value = Float.to_string median_time;
+       units = "s";
+       description = "median time result";
+     }
+      : Benchmark_result.Metric.t)
+  in
+  let throughput =
+    ({
+       name = "throughput";
+       value = Float.to_string median_throughput;
+       units = "item/s";
+       description = "median throughput result";
+     }
+      : Benchmark_result.Metric.t)
+  in
+  let metrics = [time; throughput] in 
+  ({name = "spsc-queue"; metrics} : Benchmark_result.t);;
+
+let bench () =
+  let results = ref [] in
+  for i = 1 to 10 do
+    let time = run () in
+    if i > 1 then results := time :: !results
+  done;
+  let results = List.sort Float.compare !results in
+  let median_time = List.nth results 4 in
+  let throughput = Float.of_int item_count /. median_time in
+  create_output median_time throughput;;
+  
+  

--- a/bench/bench_spsc_queue.ml
+++ b/bench/bench_spsc_queue.ml
@@ -29,7 +29,7 @@ let create_output median_time median_throughput =
   let time =
     ({
        name = "time";
-       value = Float.to_string median_time;
+       value = `Numeric median_time;
        units = "s";
        description = "median time result";
      }
@@ -38,7 +38,7 @@ let create_output median_time median_throughput =
   let throughput =
     ({
        name = "throughput";
-       value = Float.to_string median_throughput;
+       value = `Numeric median_throughput;
        units = "item/s";
        description = "median throughput result";
      }

--- a/bench/bench_spsc_queue.mli
+++ b/bench/bench_spsc_queue.mli
@@ -1,0 +1,1 @@
+val bench : unit -> Benchmark_result.t

--- a/bench/benchmark_result.ml
+++ b/bench/benchmark_result.ml
@@ -1,0 +1,19 @@
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+module Metric = struct 
+  type t = {
+    name : string; 
+    value : string;
+    units : string;
+    description : string;
+  } [@@deriving yojson]
+end 
+
+
+type t = {
+  name : string;
+  metrics : Metric.t list 
+} [@@deriving yojson]
+
+  
+

--- a/bench/benchmark_result.ml
+++ b/bench/benchmark_result.ml
@@ -1,5 +1,3 @@
-open Ppx_yojson_conv_lib.Yojson_conv.Primitives
-
 module Metric = struct 
   type t = {
     name : string; 

--- a/bench/benchmark_result.ml
+++ b/bench/benchmark_result.ml
@@ -1,17 +1,23 @@
-module Metric = struct 
+module Metric = struct
   type t = {
-    name : string; 
-    value : string;
+    name : string;
+    value : [ `Text of string | `Numeric of float ];
     units : string;
     description : string;
-  } [@@deriving yojson]
-end 
+  }
 
+  let to_json { name; value; units; description } =
+    let value_str =
+      match value with
+      | `Text text -> Printf.sprintf {|"%s"|} text
+      | `Numeric number -> Printf.sprintf {|%f|} number
+    in
+    Printf.sprintf {| {"name":"%s", "value":%s, "units":"%s", "description":"%s"} |}
+      name value_str units description
+end
 
-type t = {
-  name : string;
-  metrics : Metric.t list 
-} [@@deriving yojson]
+type t = { name : string; metrics : Metric.t list }
 
-  
-
+let to_json { name; metrics } =
+  let metrics = List.map Metric.to_json metrics |> String.concat ", " in
+  Printf.sprintf {| {"name": "%s", "metrics": [%s]} |} name metrics

--- a/bench/benchmark_result.mli
+++ b/bench/benchmark_result.mli
@@ -1,0 +1,13 @@
+module Metric : sig
+  type t = {
+    name : String.t; 
+    value : String.t;
+    units : String.t;
+    description : String.t;
+  } 
+end
+
+type t = {
+  name : String.t;
+  metrics : Metric.t list 
+} [@@deriving yojson]

--- a/bench/benchmark_result.mli
+++ b/bench/benchmark_result.mli
@@ -1,7 +1,7 @@
 module Metric : sig
   type t = {
     name : String.t; 
-    value : String.t;
+    value : [ `Text of string | `Numeric of float ];
     units : String.t;
     description : String.t;
   } 
@@ -10,4 +10,6 @@ end
 type t = {
   name : String.t;
   metrics : Metric.t list 
-} [@@deriving yojson]
+} 
+
+val to_json : t -> string

--- a/bench/dune
+++ b/bench/dune
@@ -1,5 +1,3 @@
 (executable
  (name main)
- (libraries lockfree unix yojson)
- (preprocess
-  (pps ppx_deriving_yojson)))
+ (libraries lockfree unix yojson))

--- a/bench/dune
+++ b/bench/dune
@@ -2,4 +2,4 @@
  (name main)
  (libraries lockfree unix yojson)
  (preprocess
-  (pps ppx_deriving_yojson)))
+  (pps ppx_yojson_conv)))

--- a/bench/dune
+++ b/bench/dune
@@ -1,0 +1,5 @@
+(executable
+ (name main)
+ (libraries lockfree unix yojson)
+ (preprocess
+  (pps ppx_yojson_conv)))

--- a/bench/dune
+++ b/bench/dune
@@ -2,4 +2,4 @@
  (name main)
  (libraries lockfree unix yojson)
  (preprocess
-  (pps ppx_yojson_conv)))
+  (pps ppx_deriving_yojson)))

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -1,13 +1,17 @@
 let benchmark_list = [ Bench_spsc_queue.bench ]
 
-type t = { name : string; results : Benchmark_result.t list }
-[@@deriving yojson]
-
-
-
 let () =
   let results =
     List.map (fun f -> f ()) benchmark_list
+    |> List.map Benchmark_result.to_json
+    |> String.concat ", "
   in
-  Yojson.Safe.pretty_print Format.std_formatter
-    (to_yojson ({ name = "lockfree"; results } : t))
+  let output = 
+    Printf.sprintf 
+    {| {"name": "lockfree", "results": %s}|} 
+    results
+    (* Cannot use Yojson rewriters as of today none works on OCaml 5.1.0. 
+       This at least verifies that the manually crafted JSON is well-formed. *)
+    |> Yojson.Basic.prettify
+  in
+  Printf.printf "%s" output

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -10,4 +10,4 @@ let () =
     List.map (fun f -> f ()) benchmark_list
   in
   Yojson.Safe.pretty_print Format.std_formatter
-    (to_yojson ({ name = "lockfree"; results } : t))
+    (yojson_of_t ({ name = "lockfree"; results } : t))

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -1,0 +1,13 @@
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+let benchmark_list = [ Bench_spsc_queue.bench ]
+
+type t = { name : string; results : Benchmark_result.t list }
+[@@deriving yojson]
+
+let () =
+  let results =
+    List.map (fun f -> f ()) benchmark_list
+  in
+  Yojson.Safe.pretty_print Format.std_formatter
+    (yojson_of_t ({ name = "lockfree"; results } : t))

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -10,4 +10,4 @@ let () =
     List.map (fun f -> f ()) benchmark_list
   in
   Yojson.Safe.pretty_print Format.std_formatter
-    (yojson_of_t ({ name = "lockfree"; results } : t))
+    (to_yojson ({ name = "lockfree"; results } : t))

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -11,7 +11,10 @@ let () =
     {| {"name": "lockfree", "results": %s}|} 
     results
     (* Cannot use Yojson rewriters as of today none works on OCaml 5.1.0. 
-       This at least verifies that the manually crafted JSON is well-formed. *)
+       This at least verifies that the manually crafted JSON is well-formed. 
+       
+       If the type grow, we could switch to running ppx manually on 5.0.0 and 
+       pasting in its output. *)
     |> Yojson.Basic.prettify
   in
   Printf.printf "%s" output

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -1,13 +1,13 @@
-open Ppx_yojson_conv_lib.Yojson_conv.Primitives
-
 let benchmark_list = [ Bench_spsc_queue.bench ]
 
 type t = { name : string; results : Benchmark_result.t list }
 [@@deriving yojson]
+
+
 
 let () =
   let results =
     List.map (fun f -> f ()) benchmark_list
   in
   Yojson.Safe.pretty_print Format.std_formatter
-    (yojson_of_t ({ name = "lockfree"; results } : t))
+    (to_yojson ({ name = "lockfree"; results } : t))

--- a/lockfree.opam
+++ b/lockfree.opam
@@ -13,6 +13,8 @@ depends: [
   "dune" {>= "3.0"}
   "qcheck" {with-test & >= "0.18.1"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
+  "yojson" {>= "2.0.2"}
+  "ppx_yojson_conv" {>= "v0.15.0"}
 ]
 depopts: []
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/lockfree.opam
+++ b/lockfree.opam
@@ -14,7 +14,6 @@ depends: [
   "qcheck" {with-test & >= "0.18.1"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
   "yojson" {>= "2.0.2"}
-  "ppx_deriving_yojson"
 ]
 depopts: []
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/lockfree.opam
+++ b/lockfree.opam
@@ -14,7 +14,7 @@ depends: [
   "qcheck" {with-test & >= "0.18.1"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
   "yojson" {>= "2.0.2"}
-  "ppx_yojson_conv" {>= "v0.15.0"}
+  "ppx_deriving_yojson" {>= "v0.15.0"}
 ]
 depopts: []
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/lockfree.opam
+++ b/lockfree.opam
@@ -14,7 +14,7 @@ depends: [
   "qcheck" {with-test & >= "0.18.1"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
   "yojson" {>= "2.0.2"}
-  "ppx_deriving_yojson" {>= "v0.15.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
 ]
 depopts: []
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/lockfree.opam
+++ b/lockfree.opam
@@ -14,7 +14,7 @@ depends: [
   "qcheck" {with-test & >= "0.18.1"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
   "yojson" {>= "2.0.2"}
-  "ppx_deriving_yojson" {>= "3.6.1"}
+  "ppx_deriving_yojson"
 ]
 depopts: []
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/src/spsc_queue.mli
+++ b/src/spsc_queue.mli
@@ -9,7 +9,10 @@ val create : size_exponent:int -> 'a t
    [2^size_exponent].  *)
 
 val push : 'a t -> 'a -> unit
-(** [push q v] pushes [v] at the back of the queue. *)
+(** [push q v] pushes [v] at the back of the queue. 
+    
+   @raise [Full] if the queue is full.
+*)
 
 val pop : 'a t -> 'a option
 (** [pop q] removes element from head of the queue, if any. This method can be used by


### PR DESCRIPTION
This PR adds the setup for running [current-bench](https://github.com/ocurrent/current-bench). Once this is merged and we get added to the app, all benchmark results will be available in a nice [UI](https://autumn.ocamllabs.io/mirage/irmin?worker=autumn&image=ocaml%2Fopam%3Adebian-11-ocaml-4.13).

Also adds a bare-bones benchmark for SPSC Queue. 

# Testing

```
(base) ➜  lockfree git:(benchmark-setup) ✗ make bench                      
{                                   
  "name": "lockfree",
  "results": {
    "name": "spsc-queue",
    "metrics": [
      {
        "name": "time",
        "value": 0.180373,
        "units": "s",
        "description": "median time result"
      },
      {
        "name": "throughput",
        "value": 11088136.897106,
        "units": "item/s",
        "description": "median throughput result"
      }
    ]
  }
}
```