### PR TITLE
Fix results not being in a json list

### DIFF
--- a/bench/main.ml
+++ b/bench/main.ml
@@ -8,12 +8,12 @@ let () =
   in
   let output = 
     Printf.sprintf 
-    {| {"name": "lockfree", "results": %s}|} 
+    {| {"name": "lockfree", "results": [%s]}|}
     results
     (* Cannot use Yojson rewriters as of today none works on OCaml 5.1.0. 
        This at least verifies that the manually crafted JSON is well-formed. 
        
-       If the type grow, we could switch to running ppx manually on 5.0.0 and 
+       If the type grows, we could switch to running ppx manually on 5.0.0 and
        pasting in its output. *)
     |> Yojson.Basic.prettify
   in


### PR DESCRIPTION
This fixes the failure `Invalid_argument("Json: not a list")` on current-bench :)