### PR TITLE
Enable OCaml 4 compatibility

### DIFF
--- a/lockfree.opam
+++ b/lockfree.opam
@@ -11,6 +11,7 @@ tags: []
 depends: [
   "ocaml" {>= "5.0"}
   "dune" {>= "3.0"}
+  "domain_shims" {>= "0.1.0"}
   "qcheck" {with-test & >= "0.18.1"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
   "alcotest" {>= "1.6.0"}

--- a/lockfree.opam
+++ b/lockfree.opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/ocaml-multicore/lockfree.git"
 bug-reports: "https://github.com/ocaml-multicore/lockfree/issues"
 tags: []
 depends: [
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "4.12"}
   "dune" {>= "3.0"}
   "domain_shims" {>= "0.1.0"}
   "qcheck" {with-test & >= "0.18.1"}

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,4 @@
 (library
  (name lockfree)
- (public_name lockfree))
+ (public_name lockfree)
+ (libraries domain_shims))

--- a/test/spsc_queue/test_spsc_queue.ml
+++ b/test/spsc_queue/test_spsc_queue.ml
@@ -22,7 +22,10 @@ let test_full () =
   print_string "test_spsc_queue_full: ok\n"
 
 let test_parallel () =
-  let count = 1000 in
+  let count =
+    let ocaml_4 = Char.code (String.get Sys.ocaml_version 0) < Char.code '5' in
+    match ocaml_4 with true -> 100 | false -> 100_000
+  in
   let q = Spsc_queue.create ~size_exponent:2 in
   (* producer *)
   let producer =

--- a/test/spsc_queue/test_spsc_queue.ml
+++ b/test/spsc_queue/test_spsc_queue.ml
@@ -22,14 +22,14 @@ let test_full () =
   print_string "test_spsc_queue_full: ok\n"
 
 let test_parallel () =
-  let count = 100_000 in
+  let count = 1000 in
   let q = Spsc_queue.create ~size_exponent:2 in
   (* producer *)
   let producer =
     Domain.spawn (fun () ->
         for i = 1 to count do
           while not (push_not_full q i) do
-            ()
+            Domain.cpu_relax ()
           done
         done)
   in


### PR DESCRIPTION
Uses [`domain_shims`](https://gitlab.com/gasche/domain-shims) to maintain compatibility with OCaml 4. A mock `Atomic` module is available in OCaml 4 from 4.12 onward. This is a prerequisite for a sequential version of Domainslib for OCaml 4.

I've reduced the count in spsc test, as the original count was taking > 20 minutes. 