### PR TITLE
Fix Ws_deque.push documentation

### DIFF
--- a/src/ws_deque.mli
+++ b/src/ws_deque.mli
@@ -21,7 +21,7 @@ module type S = sig
   (** Returns a fresh empty work-stealing queue *)
 
   val push : 'a t -> 'a -> unit
-  (** [push q v] pushes [v] to the back of the queue.
+  (** [push q v] pushes [v] to the front of the queue.
       It should only be invoked by the domain which owns the queue [q]. *)
 
   val pop : 'a t -> 'a


### PR DESCRIPTION
The `Ws_deque` actually behaves like a stack for the owner of the deque!