### PR TITLE
Avoid TSan warning in the test-suite

### DIFF
--- a/test/qcheck_mpsc_queue.ml
+++ b/test/qcheck_mpsc_queue.ml
@@ -434,7 +434,8 @@ let tests_one_consumer_two_producers =
 
           let multi_push lpush =
             Semaphore.Counting.acquire sema;
-            while Semaphore.Counting.get_value sema <> 0 do
+            while Semaphore.Counting.try_acquire sema do
+              Semaphore.Counting.release sema;
               Domain.cpu_relax ()
             done;
             try
@@ -505,7 +506,8 @@ let tests_one_consumer_two_producers =
 
           let guard_push lpush =
             Semaphore.Counting.acquire sema;
-            while Semaphore.Counting.get_value sema <> 0 do
+            while Semaphore.Counting.try_acquire sema do
+              Semaphore.Counting.release sema;
               Domain.cpu_relax ()
             done;
             let closed_when_pushing =
@@ -532,7 +534,8 @@ let tests_one_consumer_two_producers =
           (* Waiting to make sure the producers have time to
              start. However, as the consumer will [pop] until one of
              the producer closes the queue, it is not a requirement to wait here. *)
-          while Semaphore.Counting.get_value sema <> 0 do
+          while Semaphore.Counting.try_acquire sema do
+            Semaphore.Counting.release sema;
             Domain.cpu_relax ()
           done;
 

--- a/test/qcheck_ws_deque.ml
+++ b/test/qcheck_ws_deque.ml
@@ -237,7 +237,8 @@ let tests_one_producer_two_stealers =
           let multiple_steal deque nsteal =
             Semaphore.Counting.acquire sema;
             let res = Array.make nsteal None in
-            while Semaphore.Counting.get_value sema <> 0 do
+            while Semaphore.Counting.try_acquire sema do
+              Semaphore.Counting.release sema;
               Domain.cpu_relax ()
             done;
             for i = 0 to nsteal - 1 do

--- a/test/test_ws_deque.ml
+++ b/test/test_ws_deque.ml
@@ -31,6 +31,8 @@ let test_push_and_steal () =
   Array.iter Domain.join domains;
   print_string "test_push_and_steal: ok\n"
 
+let tailrec_concat l1 l2 = List.rev_append (List.rev l1) l2
+
 let test_concurrent_workload () =
   (* The desired number of push events. *)
   let n = ref 100000 in
@@ -109,8 +111,10 @@ let test_concurrent_workload () =
   in
   assert (npushed = npopped + nstolen);
   let sort xs = List.sort compare xs in
-  let stolen = Array.fold_left (fun accu stolen -> accu @ stolen) [] stolen in
-  assert (sort pushed = sort (popped @ stolen));
+  let stolen =
+    Array.fold_left (fun accu stolen -> tailrec_concat accu stolen) [] stolen
+  in
+  assert (sort pushed = sort (tailrec_concat popped stolen));
   (* Print a completion message. *)
   Printf.printf
     "test_concurrent_workload: ok (pushed = %d, popped = %d, stolen = %d)\n"


### PR DESCRIPTION
In the continued joint effort with @OlivierNicole to understand the TSan crash in the testsuite, we propose a few changes:
- Avoid the risk of overflowing TSan shadow task (causing a SEGV) when too many '@' calls are nested by using tail-recursive calls.
- Avoid some data race detection in the tests that wait for the other domain by replacing the polling of `Semaphore.Counting.get_value` with a `Semaphore.Counting.try_acquire`.