### PR TITLE
Renaming lockfree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ tmp
 *.native
 *.byte
 *.merlin
+*.json
+node_modules

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
 profile = default
-version = 0.23.0
+version = 0.25.1

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,14 @@
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": false,
+  "printWidth": 80,
+  "semi": false,
+  "singleQuote": true,
+  "proseWrap": "always",
+  "overrides": [
+    {
+      "files": ["*.md"],
+      "excludeFiles": "_build/*"
+    }
+  ]
+}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,23 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## Not released
 
-* Add STM tests for current data structures (@lyrm, @jmid)
+- Rename data structures and package, add docs (@lyrm)
+- Add STM tests for current data structures (@lyrm, @jmid)
 
 ## 0.3.1
 
-* Rework dscheck integration to work with utop (@lyrm)
-* Add OCaml 4 compatability (@sudha247)
-* Add STM ws_deque tests (@jmid, @lyrm)
+- Rework dscheck integration to work with utop (@lyrm)
+- Add OCaml 4 compatability (@sudha247)
+- Add STM ws_deque tests (@jmid, @lyrm)
 
 ## 0.3.0
 
-* Add MPSC queue (@lyrm)
-* Add SPSC queue (@bartoszmodelski)
-* Add MPMC relaxed queue (@bartoszmodelski, @lyrm)
-* Add Michael-Scott Queue (@tmcgilchrist, @bartoszmodelski, @lyrm)
-* Add Treiber Stack (@tmcgilchrist , @bartoszmodelski, @lyrm)
-* Integrate model-checker (DSCheck) (@bartoszmodelski)
+- Add MPSC queue (@lyrm)
+- Add SPSC queue (@bartoszmodelski)
+- Add MPMC relaxed queue (@bartoszmodelski, @lyrm)
+- Add Michael-Scott Queue (@tmcgilchrist, @bartoszmodelski, @lyrm)
+- Add Treiber Stack (@tmcgilchrist , @bartoszmodelski, @lyrm)
+- Integrate model-checker (DSCheck) (@bartoszmodelski)
 
 ## v0.2.0
 
-* Add Chase-Lev Work-stealing deque `Ws_deque`. (@ctk21)
+- Add Chase-Lev Work-stealing deque `Ws_deque`. (@ctk21)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+## Contributing
+
+Any contributions are appreciated! Please create issues/PRs to this repo.
+
+### Maintainers
+
+The current list of maintainers is as follows:
+
+- @kayceesrk KC Sivaramakrishnan
+- @lyrm Carine Morel
+- @Sudha247 Sudha Parimala
+
+### Guidelines for new data structures implementation
+
+Reviewing most implementation takes times. Here are a few guidelines to make it
+easier for the reviewers :
+
+- the issue tracker has a good list of data structures to choose from
+- implement a well know algorithm (there are a lot !)
+  - from a _reviewed_ paper, ideally with proof of main claimed properties (like
+    lock-freedom, deadlock freedom etc..)
+  - from a well known and used concurrent library (like `java.util.concurrent`)
+- write tests with **multiple** domains. All the following tests are expected to
+  be provided before a proper review is done, especially for implementations
+  that do not come from a well-know algorithm :
+  - unitary tests and `qcheck tests` : with one and multiple domains. If domains
+    have specific roles (producer, consumer, stealer, etc..), it should appear
+    in the tests.
+  - tests using `STM` from `multicoretest`
+  - (_optional_) `dscheck` tests (for non-blocking implementation)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
-# `lockfree` — Lock-free data structures for Multicore OCaml
---------------------------------------------------------
+# `Saturn` — parallelism-safe data structures for Multicore OCaml
 
-A collection of Concurrent Lockfree Data Structures for OCaml 5. It contains:
+---
 
-* [Treiber Stack](src/treiber_stack.mli) A classic multi-producer multi-consumer stack, robust and flexible. Recommended starting point when needing LIFO structure. 
-  
-* [Michael-Scott Queue](src/michael_scott_queue.mli) A classic multi-producer multi-consumer queue, robust and flexible. Recommended starting point when needing FIFO structure. It is based on [Simple, Fast, and Practical Non-Blocking and Blocking Concurrent Queue Algorithms](https://www.cs.rochester.edu/~scott/papers/1996_PODC_queues.pdf).
+A collection of parallelism-safe data structures for OCaml 5. It contains:
 
-* [Chase-Lev Work-Stealing Deque](src/ws_deque.mli) Single-producer, multi-consumer dynamic-size double-ended queue (deque) (see [Dynamic circular work-stealing deque](https://dl.acm.org/doi/10.1145/1073970.1073974) and [Correct and efficient work-stealing for weak memory models](https://dl.acm.org/doi/abs/10.1145/2442516.2442524)). Ideal for throughput-focused scheduling using per-core work distribution. Note, [pop] and [steal] follow different ordering (respectively LIFO and FIFO) and have different linearization contraints.
-
-* [SPSC Queue](src/spsc_queue.mli) Simple single-producer single-consumer fixed-size queue. Thread-safe as long as at most one thread acts as producer and at most one as consumer at any single point in time.
-
-* [MPMC Relaxed Queue](src/mpmc_relaxed_queue.mli) Multi-producer, multi-consumer, fixed-size relaxed queue. Optimised for high number of threads. Not strictly FIFO. Note, it exposes two interfaces: a lockfree and a non-lockfree (albeit more practical) one. See the mli for details. 
-
-* [MPSC Queue](src/mpsc_queue.mli) A multi-producer, single-consumer, thread-safe queue without support for cancellation. This makes a good data structure for a scheduler's run queue. It is used in [Eio](https://github.com/ocaml-multicore/eio). It is a single consumer version of the queue described in [Implementing lock-free queues](https://people.cs.pitt.edu/~jacklange/teaching/cs2510-f12/papers/implementing_lock_free.pdf).
+| Name                                               | What is it ?                                                                                                                                                                                                                                                                   | Sources                                                                                                                                                                                                      |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Treiber Stack](src/treiber_stack.mli)             | A classic multi-producer multi-consumer stack, robust and flexible. Recommended starting point when needing LIFO structure                                                                                                                                                     |                                                                                                                                                                                                              |
+| [Michael-Scott Queue](src/michael_scott_queue.mli) | A classic multi-producer multi-consumer queue, robust and flexible. Recommended starting point when needing FIFO structure.                                                                                                                                                    | [Simple, Fast, and Practical Non-Blocking and Blocking Concurrent Queue Algorithms](https://www.cs.rochester.edu/~scott/papers/1996_PODC_queues.pdf)                                                         |
+| [Chase-Lev Work-Stealing Deque](src/ws_deque.mli)  | Single-producer, multi-consumer dynamic-size double-ended queue (deque). Ideal for throughput-focused scheduling using per-core work distribution. Note, `pop` and `steal` follow different ordering (respectively LIFO and FIFO) and have different linearization contraints. | [Dynamic circular work-stealing deque](https://dl.acm.org/doi/10.1145/1073970.1073974) and [Correct and efficient work-stealing for weak memory models](https://dl.acm.org/doi/abs/10.1145/2442516.2442524)) |
+| [SPSC Queue](src/spsc_queue.mli)                   | Simple single-producer single-consumer fixed-size queue. Thread-safe as long as at most one thread acts as producer and at most one as consumer at any single point in time.                                                                                                   |                                                                                                                                                                                                              |
+| [MPMC Relaxed Queue](src/mpmc_relaxed_queue.mli)   | Multi-producer, multi-consumer, fixed-size relaxed queue. Optimised for high number of threads. Not strictly FIFO. Note, it exposes two interfaces: a lockfree and a non-lockfree (albeit more practical) one. See the mli for details.                                        |                                                                                                                                                                                                              |
+| [MPSC Queue](src/mpsc_queue.mli)                   | A multi-producer, single-consumer, thread-safe queue without support for cancellation. This makes a good data structure for a scheduler's run queue. It is used in [Eio](https://github.com/ocaml-multicore/eio).                                                              | It is a single consumer version of the queue described in [Implementing lock-free queues](https://people.cs.pitt.edu/~jacklange/teaching/cs2510-f12/papers/implementing_lock_free.pdf).                      |
 
 ## Usage
 
-lockfree can be installed from `opam`: `opam install lockfree`. Sample usage of
+`Saturn` can be installed from `opam`: `opam install saturn`. Sample usage of
 `Ws_deque` is illustrated below.
 
 ```ocaml
@@ -30,11 +28,26 @@ let () = Ws_deque.push q 100
 let () = assert (Ws_deque.pop q = 100)
 ```
 
+## Tests
+
+Several kind of tests are provided for each data structure:
+
+- unitary tests and `qcheck` tests: check semantics and expected behaviors with
+  one and more domains;
+- `STM` tests: check _linearizability_ for two domains (see
+  [multicoretests library](https://github.com/ocaml-multicore/multicoretests));
+- `dscheck`: checks _non-blocking_ property for as many domains as wanted (for
+  two domains most of the time). See
+  [dscheck](https://github.com/ocaml-multicore/dscheck).
+
+See [test/README.md](test/README.md) for more details.
+
 ## Benchmarks
 
-There is a number of benchmarks in `bench/` directory. You can run them with `make bench`. See [bench/README.md](bench/README.md) for more details.
+There is a number of benchmarks in `bench` directory. You can run them with
+`make bench`. See [bench/README.md](bench/README.md) for more details.
 
 ## Contributing
 
-Contributions of more lockfree data structures appreciated! Please create
+Contributions of more parallelism-safe data structures appreciated! Please create
 issues/PRs to this repo.

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,11 +1,13 @@
-Benchmarks for lockfree
+Benchmarks for Saturn
 
-# General usage 
+# General usage
 
-Execute `make bench` from root of the repository to run the standard set of benchmarks. The output is in JSON, as it is intended to be consumed by ocaml-benchmark CI (in progress). 
+Execute `make bench` from root of the repository to run the standard set of
+benchmarks. The output is in JSON, as it is intended to be consumed by
+ocaml-benchmark CI (in progress).
 
-# Specific structures 
+# Specific structures
 
 Some benchmarks expose commandline interface targeting particular structures:
 
-* [mpmc_queue.exe](mpmc_queue_cmd.ml)
+- [mpmc_queue.exe](mpmc_queue_cmd.ml)

--- a/bench/backoff.ml
+++ b/bench/backoff.ml
@@ -5,7 +5,7 @@ type 'a t = { value : 'a; next : 'a t option Atomic.t }
 let empty () = { value = Obj.magic (); next = Atomic.make None }
 
 let push ~backoff_once t value =
-  let b = Lockfree.Backoff.create () in
+  let b = Saturn.Backoff.create () in
   let new_head = ({ value; next = Atomic.make None } : 'a t) in
   let rec push_f () =
     let head = Atomic.get t.next in
@@ -18,7 +18,7 @@ let push ~backoff_once t value =
   push_f ()
 
 let rec pop ?min_wait ~backoff_once t =
-  let b = Lockfree.Backoff.create ?min_wait () in
+  let b = Saturn.Backoff.create ?min_wait () in
   let head = Atomic.get t.next in
   match head with
   | None -> None
@@ -95,8 +95,8 @@ let run_artificial ~backoff_once () =
 
 let bench ~run_type ~with_backoff () =
   let backoff_once =
-    if with_backoff then Lockfree.Backoff.once
-    else fun (_ : Lockfree.Backoff.t) -> ()
+    if with_backoff then Saturn.Backoff.once
+    else fun (_ : Saturn.Backoff.t) -> ()
   in
   let results = ref [] in
   let run =

--- a/bench/bench_spsc_queue.ml
+++ b/bench/bench_spsc_queue.ml
@@ -1,4 +1,4 @@
-open Lockfree
+module Spsc_queue = Saturn.Single_prod_single_cons_queue
 
 let item_count = 2_000_000
 

--- a/bench/dune
+++ b/bench/dune
@@ -1,3 +1,3 @@
 (executables
  (names main mpmc_queue_cmd)
- (libraries lockfree unix yojson))
+ (libraries saturn unix yojson))

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -27,7 +27,7 @@ let () =
     |> String.concat ", "
   in
   let output =
-    Printf.sprintf {| {"name": "lockfree", "results": [%s]}|} results
+    Printf.sprintf {| {"name": "saturn", "results": [%s]}|} results
     (* Cannot use Yojson rewriters as of today none works on OCaml 5.1.0.
        This at least verifies that the manually crafted JSON is well-formed.
 

--- a/bench/mpmc_queue.ml
+++ b/bench/mpmc_queue.ml
@@ -1,4 +1,4 @@
-open Lockfree.Mpmc_relaxed_queue
+open Saturn.Relaxed_queue
 
 let num_of_elements = ref 500_000
 let num_of_pushers = ref 4
@@ -57,8 +57,8 @@ let create_output ~time_median ~throughput_median ~throughput_stddev =
 
 let run_bench () =
   if !use_cas_intf then (
-    push := Lockfree.Mpmc_relaxed_queue.Not_lockfree.CAS_interface.push;
-    pop := Lockfree.Mpmc_relaxed_queue.Not_lockfree.CAS_interface.pop);
+    push := Saturn.Relaxed_queue.Not_lockfree.CAS_interface.push;
+    pop := Saturn.Relaxed_queue.Not_lockfree.CAS_interface.pop);
   let queue = create ~size_exponent:10 () in
   let orchestrator =
     Orchestrator.init

--- a/bench/orchestrator.mli
+++ b/bench/orchestrator.mli
@@ -1,8 +1,37 @@
-(** Helper library that ensures all workers have started before any 
+(** Helper library that ensures all workers have started before any
   starts making progress on the benchmark. *)
 
 type t
+(** An orchestrator is similar to a counter that ensures each domain
+    has started and complete each round simultanously. All domains
+    wait for the other before beginning the next round. *)
 
 val init : total_domains:int -> rounds:int -> t
+(** [init ~total_domains:nd ~rounds:nr] create an orchestrator that
+    will run [nr] rounds for a test that uses exactly [nd] worker
+    domains *)
+
 val worker : t -> (unit -> unit) -> unit
+(** [worker t f] builds the function to pass to [Domain.spawn] while
+    using the orchestrator [t]. Doing [Domain.spawn (fun () -> worker
+    t f)] is similar to [Domain.spawn f] except that the orchestrator
+    is used to synchronize all domains progress.
+ *)
+
 val run : ?drop_first:bool -> t -> float List.t
+(** [run t] is launching the benchmark by enabling domains to progress. Benchmarks code should have the following structure :
+
+{[
+   (* Initialize the orchestrator, with [nd] the number of domains we want. *)
+   let orchestrator = init ~total_domain:nd ~round:100 in
+   (* Spawn domains with [worker] *)
+   let domains =
+         List.init nd (fun _ ->
+               Domain.spawn (fun () ->
+                      worker orchestrator (fun () -> some_function ()))) in
+   (* Run the benchmarks by freeing domains round by round. *)
+   let times = run orchestrator in
+   ...
+]}
+
+*)

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
 (lang dune 3.0)
-(name lockfree)
+(name saturn)

--- a/saturn.opam
+++ b/saturn.opam
@@ -1,12 +1,12 @@
 opam-version: "2.0"
-maintainer: "KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"
+maintainer:"KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"
 authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
-homepage: "https://github.com/ocaml-multicore/lockfree"
-doc: "https://ocaml-multicore.github.io/lockfree"
-synopsis: "Lock-free data structures for multicore OCaml"
+homepage: "https://github.com/ocaml-multicore/saturn"
+doc: "https://ocaml-multicore.github.io/saturn"
+synopsis: "Parallelism-safe data structures for multicore OCaml"
 license: "ISC"
-dev-repo: "git+https://github.com/ocaml-multicore/lockfree.git"
-bug-reports: "https://github.com/ocaml-multicore/lockfree/issues"
+dev-repo: "git+https://github.com/ocaml-multicore/saturn.git"
+bug-reports: "https://github.com/ocaml-multicore/saturn/issues"
 tags: []
 depends: [
   "ocaml" {>= "4.12"}

--- a/seqtest/dune
+++ b/seqtest/dune
@@ -1,6 +1,6 @@
 (executable
  (name seqtest)
- (libraries monolith lockfree)
+ (libraries monolith saturn)
  (modules seqtest)
  (enabled_if
   (= %{profile} seqtest)))

--- a/seqtest/seqtest.ml
+++ b/seqtest/seqtest.ml
@@ -1,5 +1,5 @@
 open Monolith
-open Lockfree.Ws_deque
+open Saturn.Work_stealing_deque
 
 (* This sequential implementation of stacks serves as a reference. *)
 

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
- (name lockfree)
- (public_name lockfree)
+ (name saturn)
+ (public_name saturn)
  (libraries domain_shims))

--- a/src/michael_scott_queue.mli
+++ b/src/michael_scott_queue.mli
@@ -16,9 +16,10 @@
  *)
 
 (**
-   Michael-Scott Queue. A classic multi-producer multi-consumer queue,
-   robust and flexible.  Recommended starting point when needing FIFO
-   structure. It is inspired by {{:
+    Michael-Scott classic multi-producer multi-consumer queue.
+
+   All functions are lockfree. It is the recommended starting point
+   when needing FIFO structure. It is inspired by {{:
    https://www.cs.rochester.edu/~scott/papers/1996_PODC_queues.pdf}
    Simple, Fast, and Practical Non-Blocking and Blocking Concurrent
    Queue Algorithms}.
@@ -28,17 +29,17 @@ type 'a t
 (** The type of lock-free queue. *)
 
 val create : unit -> 'a t
-(** Create a new queue, which is initially empty. *)
+(** [create ()] returns a new queue, initially empty. *)
 
 val is_empty : 'a t -> bool
 (** [is_empty q] returns empty if [q] is empty. *)
 
 val push : 'a t -> 'a -> unit
-(** [push q v] pushes [v] to the back of the queue. *)
+(** [push q v] adds the element [v] at the end of the queue [q]. *)
 
 val pop : 'a t -> 'a option
-(** [pop q] pops an element [e] from the front of the queue and returns
-    [Some v] if the queue is non-empty. Otherwise, returns [None]. *)
+(** [pop q] removes and returns the first element in queue [q], or
+    returns [None] if the queue is empty. *)
 
 val clean_until : 'a t -> ('a -> bool) -> unit
 (** [clean_until q f] drops the prefix of the queue until the element [e],

--- a/src/mpmc_relaxed_queue.mli
+++ b/src/mpmc_relaxed_queue.mli
@@ -1,18 +1,18 @@
-(** 
-    A lock-free multi-producer, multi-consumer, thread-safe, relaxed-FIFO queue. 
+(**
+    A multi-producer, multi-consumer, thread-safe, relaxed-FIFO queue.
 
-    It exposes two interfaces: [Spin] and [Not_lockfree]. [Spin] is lock-free 
-    formally, but the property is achieved in a fairly counterintuitive way - 
+    It exposes two interfaces: [Spin] and [Not_lockfree]. [Spin] is lock-free
+    formally, but the property is achieved in a fairly counterintuitive way -
     - by using the fact that lock-freedom does not impose any constraints on
-    partial methods. In simple words, an invocation of function that cannot 
-    logically terminate (`push` on full queue, `pop` on empty queue), it is 
-    allowed to *busy-wait* until the precondition is meet. 
+    partial methods. In simple words, an invocation of function that cannot
+    logically terminate (`push` on full queue, `pop` on empty queue), it is
+    allowed to *busy-wait* until the precondition is meet.
 
-    Above interface is impractical outside specialized applications. Thus, 
-    [Mpmc_relaxed_queue] also exposes [Not_lockfree] interface. [Not_lockfree] 
-    contains non-lockfree paths. While formally a locked algorithm, it will 
-    often be the more practical solution as it allows having an overflow 
-    queue, etc. 
+    Above interface is impractical outside specialized applications. Thus,
+    [Mpmc_relaxed_queue] also exposes [Not_lockfree] interface. [Not_lockfree]
+    contains non-lockfree paths. While formally a locked algorithm, it will
+    often be the more practical solution as it allows having an overflow
+    queue, etc.
 *)
 
 type 'a t = private {
@@ -28,22 +28,22 @@ val create : size_exponent:int -> unit -> 'a t
     [2^size_exponent].  *)
 
 module Spin : sig
-  (** [Spin] exposes a formally lock-free interface as per the [A lock-free relaxed 
-    concurrent queue for fast work distribution] paper. Functions here busy-wait if 
+  (** [Spin] exposes a formally lock-free interface as per the [A lock-free relaxed
+    concurrent queue for fast work distribution] paper. Functions here busy-wait if
     the action cannot be completed (i.e. [push] on full queue, [pop] on empty queue). *)
 
   val push : 'a t -> 'a -> unit
-  (** [push t x] adds [x] to the tail of the queue. If the queue is full, [push] 
+  (** [push t x] adds [x] to the tail of the queue. If the queue is full, [push]
        busy-waits until another thread removes an item. *)
 
   val pop : 'a t -> 'a
-  (** [pop t] removes an item from the head of the queue. If the queue is empty, 
+  (** [pop t] removes an item from the head of the queue. If the queue is empty,
        [pop] busy-waits until an item appear. *)
 end
 
 module Not_lockfree : sig
-  (** [Non_lockfree] exposes an interface that contains non-lockfree paths, i.e. threads 
-    may need to cooperate to terminate. It is often more practical than [Spin], in 
+  (** [Non_lockfree] exposes an interface that contains non-lockfree paths, i.e. threads
+    may need to cooperate to terminate. It is often more practical than [Spin], in
     particular when using a fair OS scheduler. *)
 
   val push : 'a t -> 'a -> bool
@@ -55,10 +55,10 @@ module Not_lockfree : sig
         Returns [None] if [t] is currently empty. *)
 
   module CAS_interface : sig
-    (** Alternative interface, which may perform better on architectures without 
-        FAD instructions (e.g. AArch). 
+    (** Alternative interface, which may perform better on architectures without
+        FAD instructions (e.g. AArch).
 
-        CAS_interface should not be the default choice. It may be a little faster 
+        CAS_interface should not be the default choice. It may be a little faster
         on ARM, but it is going to be a few times slower than standard on x86.
         *)
 

--- a/src/saturn.ml
+++ b/src/saturn.ml
@@ -4,10 +4,6 @@
    %%NAME%% %%VERSION%%
   ---------------------------------------------------------------------------*)
 
-(** Lock-free data structures for Multicore OCaml *)
-
-(** {1 Lockfree} *)
-
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 KC Sivaramakrishnan
 
@@ -30,10 +26,10 @@ Copyright (c) 2017, Nicolas ASSOUAD <nicolas.assouad@ens.fr>
 ########
 *)
 
-module Ws_deque = Ws_deque
-module Spsc_queue = Spsc_queue
-module Mpsc_queue = Mpsc_queue
-module Treiber_stack = Treiber_stack
-module Michael_scott_queue = Michael_scott_queue
-module Mpmc_relaxed_queue = Mpmc_relaxed_queue
+module Queue = Michael_scott_queue
+module Stack = Treiber_stack
+module Work_stealing_deque = Ws_deque
+module Single_prod_single_cons_queue = Spsc_queue
+module Single_consumer_queue = Mpsc_queue
+module Relaxed_queue = Mpmc_relaxed_queue
 module Backoff = Backoff

--- a/src/saturn.mli
+++ b/src/saturn.mli
@@ -25,10 +25,18 @@
 Copyright (c) 2017, Nicolas ASSOUAD <nicolas.assouad@ens.fr>
 ########
 *)
-module Ws_deque = Ws_deque
-module Spsc_queue = Spsc_queue
-module Mpsc_queue = Mpsc_queue
-module Treiber_stack = Treiber_stack
-module Michael_scott_queue = Michael_scott_queue
+
+(** Domain-safe data structures for Multicore OCaml *)
+
+(** {1 Data structures} *)
+
+module Queue = Michael_scott_queue
+module Stack = Treiber_stack
+module Work_stealing_deque = Ws_deque
+module Single_prod_single_cons_queue = Spsc_queue
+module Single_consumer_queue = Mpsc_queue
+module Relaxed_queue = Mpmc_relaxed_queue
+
+(** {2 Other} *)
+
 module Backoff = Backoff
-module Mpmc_relaxed_queue = Mpmc_relaxed_queue

--- a/src/spsc_queue.mli
+++ b/src/spsc_queue.mli
@@ -1,24 +1,29 @@
+(** Single producer single consumer queue. *)
+
 type 'a t
-(** Type of single-producer single-consumer non-resizable thread-safe
+(** Type of single-producer single-consumer non-resizable domain-safe
    queue that works in FIFO order. *)
 
 exception Full
+(** Raised when {!push} is applied to a full queue. *)
 
 val create : size_exponent:int -> 'a t
-(** [create ~size_exponent:int] creates a empty queue of size
-   [2^size_exponent].  *)
+(** [create ~size_exponent:int] returns a new queue of maximum size
+   [2^size_exponent] and initially empty. *)
 
 val push : 'a t -> 'a -> unit
-(** [push q v] pushes [v] at the back of the queue. 
-    
+(** [push q v] adds the element [v] at the end of the queue [q]. This
+    method can be used by at most one domain at the time.
+
    @raise [Full] if the queue is full.
 *)
 
 val pop : 'a t -> 'a option
-(** [pop q] removes element from head of the queue, if any. This method can be used by
-  at most 1 thread at the time. *)
+(** [pop q] removes and returns the first element in queue [q], or
+    returns [None] if the queue is empty. This method can be used by
+    at most one domain at the time. *)
 
 val size : 'a t -> int
 (** [size] returns the size of the queue. This method linearizes only when called
-  from either enqueuer or dequeuer thread. Otherwise, it is safe to call but
+  from either consumer or producer domain. Otherwise, it is safe to call but
   provides only an *indication* of the size of the structure. *)

--- a/src/treiber_stack.mli
+++ b/src/treiber_stack.mli
@@ -1,17 +1,20 @@
-(** Classic multi-producer multi-consumer Treiber stack. Robust and flexible. 
-    Recommended starting point when needing LIFO structure. *)
+(** Classic multi-producer multi-consumer Treiber stack.
+
+    All function are lockfree. It is the recommended starting point
+    when needing LIFO structure. *)
 
 type 'a t
 (** Type of Treiber stack holding items of type [t]. *)
 
 val create : unit -> 'a t
-(** [create] creates an empty Treiber stack. *)
+(** [create ()] returns a new and empty Treiber stack. *)
 
 val is_empty : 'a t -> bool
-(** [is_empty] checks whether stack is empty. *)
+(** [is_empty s] checks whether stack [s] is empty. *)
 
 val push : 'a t -> 'a -> unit
-(** [push] inserts element into the stack. *)
+(** [push s v] adds the element [v] at the top of stack [s]. *)
 
 val pop : 'a t -> 'a option
-(** [pop] removes the youngest element from the stack (if any). *)
+(** [pop a] removes and returns the topmost element in the
+    stack [s], or returns [None] if the stack is empty. *)

--- a/src/ws_deque.mli
+++ b/src/ws_deque.mli
@@ -1,16 +1,16 @@
-(** A lock-free single-producer, multi-consumer dynamic-size double-ended queue (deque). 
+(** Lock-free single-producer, multi-consumer dynamic-size double-ended queue (deque).
 
     The main strength of deque in a typical work-stealing setup with per-core structure
-    is efficient work distribution. Owner uses [push] and [pop] method to operate at 
-    one end of the deque, while other (free) cores can efficiently steal work on the 
-    other side. 
-    
-    This approach is great for throughput. Stealers and owner working on different sides 
-    reduces contention in work distribution. Further, local LIFO order runs related tasks 
-    one after one improves locality. 
+    is efficient work distribution. Owner uses [push] and [pop] method to operate at
+    one end of the deque, while other (free) cores can efficiently steal work on the
+    other side.
 
-    On the other hand, the local LIFO order does not offer any fairness guarantees. 
-    Thus, it is not the best choice when tail latency matters. 
+    This approach is great for throughput. Stealers and owner working on different sides
+    reduces contention in work distribution. Further, local LIFO order runs related tasks
+    one after one improves locality.
+
+    On the other hand, the local LIFO order does not offer any fairness guarantees.
+    Thus, it is not the best choice when tail latency matters.
 *)
 
 module type S = sig
@@ -18,22 +18,28 @@ module type S = sig
   (** Type of work-stealing queue *)
 
   val create : unit -> 'a t
-  (** Returns a fresh empty work-stealing queue *)
+  (** [create ()] returns a new empty work-stealing queue. *)
+
+  (** {1 Queue owner functions} *)
 
   val push : 'a t -> 'a -> unit
-  (** [push q v] pushes [v] to the front of the queue.
+  (** [push t v] adds [v] to the front of the queue [q].
       It should only be invoked by the domain which owns the queue [q]. *)
 
   val pop : 'a t -> 'a
-  (** [pop q] removes an element [e] from the front of the queue and returns
-      it. It should only be invoked by the domain which owns the queue [q].
+  (** [pop q] removes and returns the first element in queue
+      [q].It should only be invoked by the domain which owns the queue
+      [q].
 
       @raise [Exit] if the queue is empty.
       *)
 
+  (** {1 Stealers function} *)
+
   val steal : 'a t -> 'a
-  (** [steal q] removes an element from the back of the queue and returns
-      it. It should only be invoked by domain which doesn't own the queue [q].
+  (** [steal q] removes and returns the last element from queue
+      [q]. It should only be invoked by domain which doesn't own the
+      queue [q].
 
       @raise [Exit] if the queue is empty.
       *)

--- a/test/README.md
+++ b/test/README.md
@@ -1,10 +1,67 @@
-## About dscheck tests
+### Introduction
 
-Dscheck tests need to use dscheck `TracedAtomic` library, which adds effects to `Stdlib.Atomic` to track calls to atomic functions. To make it work :
-- the `Atomic` standard library is shadowed by [`Dscheck.TracedAtomic`](atomic/atomic.ml)
-- every datastructure implementation is copied in its respective tests directory. The copied version is used only for dscheck tests and is compiled with the `shadowing` atomic library
+Several kind of tests are provided for each data structure:
+
+- unitary tests and `qcheck` tests: check semantics and expected behaviors with
+  one and more domains;
+- `STM` tests: also check semantics as well as _linearizability_ for two domains
+  (see
+  [multicoretests library](https://github.com/ocaml-multicore/multicoretests));
+- `dscheck` (for lockfree data structures): checks lock-freedom for as many
+  domains as wanted (for two domains most of the time). It is limited to the
+  paths explored by the tests.
+
+### Unitary parallel tests and `QCheck` tests
+
+Every data structure should have separate parallel tests for all core operations
+and for most useful combinations of them to make sure things work the way you
+expected them to, even in parallel.
+
+Inside the parallel tests, it's important to ensure there's a high chance of
+actual parallel execution. Keep in mind that spawning a domain is an expensive
+operation: if a domain only launches a few simple operations, it will most
+likely run in isolation. Here are a few tricks to ensure your tests actually
+runs with parallelism:
+
+- make a domain repeat its operations. In particular, that usually works well
+  when testing a single function.
+- use a semaphore to make all domains wait for each other before starting (see
+  [these tests for example) ](ws_deque/qcheck_ws_deque.ml)).
+- if you are still not sure your tests have a good chance to run in parallel,
+  try it in the top level, and use print or outputs to understand what is
+  happening.
+
+### Linearizability test with `STM` (see [multicoretests](https://github.com/ocaml-multicore/multicoretests))
+
+#### How to write `STM` tests ?
+
+`STM` tests work by comparing the results of two domains each executing a random
+list of method calls to a sequential model provided by the user. Most of the
+time, these tests are easy and quick to write and can catch a lot of bugs.
+
+If all domains can use every functions of the tested data structure, you can
+have a look to
+[stm test for Treiber's stack](treiber_stack/stm_treiber_stack.ml). If domains
+have specific roles (producer/consumer/stealer etc..),
+[this one](ws_deque/stm_ws_deque.ml) is for a work-stealing deque and is a
+better example.
+
+### Lock-free property with [`dscheck`](https://github.com/ocaml-multicore/dscheck).
+
+`dscheck` is a model checker. Each provided test is run multiple times, each
+time exploring a different interleaving between atomic operations. This checks
+that there is no `blocking` paths in the ones explored by these tests (if a
+trace is blocking, the test does not end)
+
+#### How is `Atomic` library shadowed ?
+
+Dscheck tests need to use dscheck `TracedAtomic` library, which adds effects to
+`Stdlib.Atomic` to track calls to atomic functions. To make it work, every
+datastructure implementation is copied in its respective tests directory and
+compiled using the `dscheck` [atomic library](atomic/atomic.ml).
 
 For example, in [ws_deque/dune](ws_deque/dune) :
+
 ```
 ; Copy implementation file and its dependencies
 (rule
@@ -19,4 +76,12 @@ For example, in [ws_deque/dune](ws_deque/dune) :
  (libraries atomic dscheck alcotest)
  (modules ArrayExtra ws_deque ws_deque_dscheck))
 ```
-Dscheck test rule does not require `lockfree` but require `atomic` which is the shadowed atomic library.
+
+We can see that `dscheck` test compilation does not depend on `lockfree` (since
+the data structure code is copy-paste in the test directory) but require
+`atomic` which is the shadowing atomic library.
+
+#### What about other progress properties ?
+
+Right now, `dscheck` only checks for lock-freedom. In a near future, it should
+also be able to deal with lock and checks for deadlock-freedom.

--- a/test/michael_scott_queue/dune
+++ b/test/michael_scott_queue/dune
@@ -11,12 +11,12 @@
 
 (test
  (name qcheck_michael_scott_queue)
- (libraries lockfree qcheck qcheck-alcotest)
+ (libraries saturn qcheck qcheck-alcotest)
  (modules qcheck_michael_scott_queue))
 
 (test
  (name stm_michael_scott_queue)
  (modules stm_michael_scott_queue)
- (libraries lockfree qcheck-stm.sequential qcheck-stm.domain)
+ (libraries saturn qcheck-stm.sequential qcheck-stm.domain)
  (action
   (run %{test} --verbose)))

--- a/test/michael_scott_queue/stm_michael_scott_queue.ml
+++ b/test/michael_scott_queue/stm_michael_scott_queue.ml
@@ -2,7 +2,7 @@
 
 open QCheck
 open STM
-module Ms_queue = Lockfree.Michael_scott_queue
+module Ms_queue = Saturn.Queue
 
 module MSQConf = struct
   type cmd = Push of int | Pop | Is_empty
@@ -61,7 +61,7 @@ let () =
   QCheck_base_runner.run_tests_main
     [
       MSQ_seq.agree_test ~count
-        ~name:"STM Lockfree.Michael_scott_queue test sequential";
+        ~name:"STM Saturn.Michael_scott_queue test sequential";
       MSQ_dom.agree_test_par ~count
-        ~name:"STM Lockfree.Michael_scott_queue test parallel";
+        ~name:"STM Saturn.Michael_scott_queue test parallel";
     ]

--- a/test/mpmc_relaxed_queue/dune
+++ b/test/mpmc_relaxed_queue/dune
@@ -1,4 +1,4 @@
 (test
  (name test_mpmc_relaxed_queue)
- (libraries lockfree unix alcotest)
+ (libraries saturn unix alcotest)
  (modules test_mpmc_relaxed_queue))

--- a/test/mpmc_relaxed_queue/test_mpmc_relaxed_queue.ml
+++ b/test/mpmc_relaxed_queue/test_mpmc_relaxed_queue.ml
@@ -1,14 +1,14 @@
-open Lockfree
+open Saturn
 
 let smoke_test (push, pop) () =
-  let queue = Mpmc_relaxed_queue.create ~size_exponent:2 () in
+  let queue = Relaxed_queue.create ~size_exponent:2 () in
   (* enqueue 4 *)
   for i = 1 to 4 do
     Alcotest.(check bool)
       "there should be space in the queue" (push queue i) true
   done;
   assert (not (push queue 0));
-  let ({ tail; head; _ } : 'a Mpmc_relaxed_queue.t) = queue in
+  let ({ tail; head; _ } : 'a Relaxed_queue.t) = queue in
   assert (Atomic.get tail = 4);
   assert (Atomic.get head = 0);
   (* dequeue 4 *)
@@ -19,7 +19,7 @@ let smoke_test (push, pop) () =
   Alcotest.(check (option int)) "queue should be empty" None (pop queue)
 
 let two_threads_test (push, pop) () =
-  let queue = Mpmc_relaxed_queue.create ~size_exponent:2 () in
+  let queue = Relaxed_queue.create ~size_exponent:2 () in
   let num_of_elements = 1_000_000 in
   (* start dequeuer *)
   let dequeuer =
@@ -58,19 +58,18 @@ let taker wfo queue num_of_elements () =
   Wait_for_others.wait wfo;
   let i = ref 0 in
   while !i < num_of_elements do
-    if Option.is_some (Mpmc_relaxed_queue.Not_lockfree.pop queue) then
-      i := !i + 1
+    if Option.is_some (Relaxed_queue.Not_lockfree.pop queue) then i := !i + 1
   done
 
 let pusher wfo queue num_of_elements () =
   Wait_for_others.wait wfo;
   let i = ref 0 in
   while !i < num_of_elements do
-    if Mpmc_relaxed_queue.Not_lockfree.push queue !i then i := !i + 1
+    if Relaxed_queue.Not_lockfree.push queue !i then i := !i + 1
   done
 
 let run_test num_takers num_pushers () =
-  let queue = Mpmc_relaxed_queue.create ~size_exponent:3 () in
+  let queue = Relaxed_queue.create ~size_exponent:3 () in
   let num_of_elements = 4_000_000 in
   let wfo = Wait_for_others.init ~total_expected:(num_takers + num_pushers) in
   let _ =
@@ -88,7 +87,7 @@ let run_test num_takers num_pushers () =
     in
     Sys.opaque_identity (List.map Domain.join (pushers @ takers))
   in
-  let ({ array; head; tail; _ } : 'a Mpmc_relaxed_queue.t) = queue in
+  let ({ array; head; tail; _ } : 'a Relaxed_queue.t) = queue in
   let head_val = Atomic.get head in
   let tail_val = Atomic.get tail in
   Alcotest.(check int) "hd an tl match" head_val tail_val;
@@ -99,38 +98,38 @@ let run_test num_takers num_pushers () =
     array
 
 let smoke_test_spinning () =
-  let queue = Mpmc_relaxed_queue.create ~size_exponent:2 () in
+  let queue = Relaxed_queue.create ~size_exponent:2 () in
   (* enqueue 4 *)
   for i = 1 to 4 do
-    Mpmc_relaxed_queue.Spin.push queue i
+    Relaxed_queue.Spin.push queue i
   done;
-  assert (not (Mpmc_relaxed_queue.Not_lockfree.push queue 0));
-  let ({ tail; head; _ } : 'a Mpmc_relaxed_queue.t) = queue in
+  assert (not (Relaxed_queue.Not_lockfree.push queue 0));
+  let ({ tail; head; _ } : 'a Relaxed_queue.t) = queue in
   assert (Atomic.get tail = 4);
   assert (Atomic.get head = 0);
   (* dequeue 4 *)
   for i = 1 to 4 do
     Alcotest.(check (option int))
       "items should come out in FIFO order" (Some i)
-      (Mpmc_relaxed_queue.Not_lockfree.pop queue)
+      (Relaxed_queue.Not_lockfree.pop queue)
   done;
   Alcotest.(check (option int))
     "queue should be empty" None
-    (Mpmc_relaxed_queue.Not_lockfree.pop queue)
+    (Relaxed_queue.Not_lockfree.pop queue)
 
 let two_threads_spin_test () =
-  let queue = Mpmc_relaxed_queue.create ~size_exponent:2 () in
+  let queue = Relaxed_queue.create ~size_exponent:2 () in
   let num_of_elements = 1_000_000 in
   (* start dequeuer *)
   let dequeuer =
     Domain.spawn (fun () ->
         for i = 1 to num_of_elements do
-          assert (Mpmc_relaxed_queue.Spin.pop queue == i)
+          assert (Relaxed_queue.Spin.pop queue == i)
         done)
   in
   (* enqueue *)
   for i = 1 to num_of_elements do
-    Mpmc_relaxed_queue.Spin.push queue i
+    Relaxed_queue.Spin.push queue i
   done;
   Domain.join dequeuer |> ignore;
   ()
@@ -138,30 +137,32 @@ let two_threads_spin_test () =
 let () =
   let open Alcotest in
   run "Mpmc_queue"
-    (let open Mpmc_relaxed_queue.Not_lockfree in
-    [
-      ( "single-thread",
-        [ test_case "is it a queue" `Quick (smoke_test (push, pop)) ] );
-      ( "validate items",
-        [ test_case "1 prod. 1 cons." `Quick (two_threads_test (push, pop)) ] );
-      ( "validate indices under load",
-        [
-          test_case " 4 prod. 4 cons." `Slow (run_test 4 4);
-          test_case " 8 prod. 1 cons." `Slow (run_test 8 1);
-          test_case " 1 prod. 8 cons." `Slow (run_test 1 8);
-        ] );
-    ]
-    @
-    let open Mpmc_relaxed_queue.Not_lockfree.CAS_interface in
-    [
-      ( "single-thread-CAS-intf",
-        [ test_case "is it a queue" `Quick (smoke_test (push, pop)) ] );
-      ( "validate items-CAS-intf",
-        [ test_case "1 prod. 1 cons." `Quick (two_threads_test (push, pop)) ] );
-    ]
-    @ [
-        ( "single-thread-spinning",
-          [ test_case "is it a queue" `Quick smoke_test_spinning ] );
-        ( "validate-items-spinning",
-          [ test_case "1 prod. 1 cons" `Quick two_threads_spin_test ] );
-      ])
+    (let open Relaxed_queue.Not_lockfree in
+     [
+       ( "single-thread",
+         [ test_case "is it a queue" `Quick (smoke_test (push, pop)) ] );
+       ( "validate items",
+         [ test_case "1 prod. 1 cons." `Quick (two_threads_test (push, pop)) ]
+       );
+       ( "validate indices under load",
+         [
+           test_case " 4 prod. 4 cons." `Slow (run_test 4 4);
+           test_case " 8 prod. 1 cons." `Slow (run_test 8 1);
+           test_case " 1 prod. 8 cons." `Slow (run_test 1 8);
+         ] );
+     ]
+     @
+     let open Relaxed_queue.Not_lockfree.CAS_interface in
+     [
+       ( "single-thread-CAS-intf",
+         [ test_case "is it a queue" `Quick (smoke_test (push, pop)) ] );
+       ( "validate items-CAS-intf",
+         [ test_case "1 prod. 1 cons." `Quick (two_threads_test (push, pop)) ]
+       );
+     ]
+     @ [
+         ( "single-thread-spinning",
+           [ test_case "is it a queue" `Quick smoke_test_spinning ] );
+         ( "validate-items-spinning",
+           [ test_case "1 prod. 1 cons" `Quick two_threads_spin_test ] );
+       ])

--- a/test/mpsc_queue/dune
+++ b/test/mpsc_queue/dune
@@ -8,12 +8,12 @@
 
 (test
  (name qcheck_mpsc_queue)
- (libraries lockfree qcheck qcheck-alcotest)
+ (libraries saturn qcheck qcheck-alcotest)
  (modules qcheck_mpsc_queue))
 
 (test
  (name stm_mpsc_queue)
  (modules stm_mpsc_queue)
- (libraries lockfree qcheck-stm.sequential qcheck-stm.domain)
+ (libraries saturn qcheck-stm.sequential qcheck-stm.domain)
  (action
   (run %{test} --verbose)))

--- a/test/mpsc_queue/qcheck_mpsc_queue.ml
+++ b/test/mpsc_queue/qcheck_mpsc_queue.ml
@@ -1,4 +1,4 @@
-module Mpsc_queue = Lockfree.Mpsc_queue
+module Mpsc_queue = Saturn.Single_consumer_queue
 
 (* Mpsc_queue is a multiple producers, single consumer queue. *)
 (* Producers can use the functions

--- a/test/mpsc_queue/stm_mpsc_queue.ml
+++ b/test/mpsc_queue/stm_mpsc_queue.ml
@@ -3,7 +3,7 @@
 open QCheck
 open STM
 open Util
-module Mpsc_queue = Lockfree.Mpsc_queue
+module Mpsc_queue = Saturn.Single_consumer_queue
 
 module MPSCConf = struct
   type cmd = Push of int | Pop | Push_head of int | Is_empty | Close
@@ -105,8 +105,8 @@ let () =
   let count = 1000 in
   QCheck_base_runner.run_tests_main
     [
-      MPSC_seq.agree_test ~count ~name:"STM Lockfree.Mpsc_queue test sequential";
-      agree_test_par_asym ~count ~name:"STM Lockfree.Mpsc_queue test parallel";
+      MPSC_seq.agree_test ~count ~name:"STM Saturn.Mpsc_queue test sequential";
+      agree_test_par_asym ~count ~name:"STM Saturn.Mpsc_queue test parallel";
       MPSC_dom.neg_agree_test_par ~count
-        ~name:"STM Lockfree.Mpsc_queue test parallel, negative";
+        ~name:"STM Saturn.Mpsc_queue test parallel, negative";
     ]

--- a/test/spsc_queue/dune
+++ b/test/spsc_queue/dune
@@ -8,17 +8,17 @@
 
 (test
  (name test_spsc_queue)
- (libraries lockfree)
+ (libraries saturn)
  (modules test_spsc_queue))
 
 (test
  (name qcheck_spsc_queue)
- (libraries lockfree qcheck "qcheck-alcotest")
+ (libraries saturn qcheck "qcheck-alcotest")
  (modules qcheck_spsc_queue))
 
 (test
  (name stm_spsc_queue)
  (modules stm_spsc_queue)
- (libraries lockfree qcheck-stm.sequential qcheck-stm.domain)
+ (libraries saturn qcheck-stm.sequential qcheck-stm.domain)
  (action
   (run %{test} --verbose)))

--- a/test/spsc_queue/qcheck_spsc_queue.ml
+++ b/test/spsc_queue/qcheck_spsc_queue.ml
@@ -1,4 +1,4 @@
-module Spsc_queue = Lockfree.Spsc_queue
+module Spsc_queue = Saturn.Single_prod_single_cons_queue
 
 let keep_some l = List.filter Option.is_some l |> List.map Option.get
 let keep_n_first n = List.filteri (fun i _ -> i < n)

--- a/test/spsc_queue/stm_spsc_queue.ml
+++ b/test/spsc_queue/stm_spsc_queue.ml
@@ -3,7 +3,7 @@
 open QCheck
 open STM
 open Util
-module Spsc_queue = Lockfree.Spsc_queue
+module Spsc_queue = Saturn.Single_prod_single_cons_queue
 
 module SPSCConf = struct
   type cmd = Push of int | Pop
@@ -79,9 +79,9 @@ let () =
   let count = 1000 in
   QCheck_base_runner.run_tests_main
     [
-      SPSC_seq.agree_test ~count ~name:"STM Lockfree.Spsc_queue test sequential";
-      agree_test_par_asym ~count ~name:"STM Lockfree.Spsc_queue test parallel";
+      SPSC_seq.agree_test ~count ~name:"STM Saturn.Spsc_queue test sequential";
+      agree_test_par_asym ~count ~name:"STM Saturn.Spsc_queue test parallel";
       (* Note: this can generate, e.g., pop commands/actions in different threads, thus violating the spec. *)
       SPSC_dom.neg_agree_test_par ~count
-        ~name:"STM Lockfree.Spsc_queue test parallel, negative";
+        ~name:"STM Saturn.Spsc_queue test parallel, negative";
     ]

--- a/test/spsc_queue/test_spsc_queue.ml
+++ b/test/spsc_queue/test_spsc_queue.ml
@@ -1,4 +1,4 @@
-open Lockfree
+module Spsc_queue = Saturn.Single_prod_single_cons_queue
 (** Tests *)
 
 let test_empty () =

--- a/test/treiber_stack/dune
+++ b/test/treiber_stack/dune
@@ -11,12 +11,12 @@
 
 (test
  (name qcheck_treiber_stack)
- (libraries lockfree qcheck qcheck-alcotest)
+ (libraries saturn qcheck qcheck-alcotest)
  (modules qcheck_treiber_stack))
 
 (test
  (name stm_treiber_stack)
  (modules stm_treiber_stack)
- (libraries lockfree qcheck-stm.sequential qcheck-stm.domain)
+ (libraries saturn qcheck-stm.sequential qcheck-stm.domain)
  (action
   (run %{test} --verbose)))

--- a/test/treiber_stack/stm_treiber_stack.ml
+++ b/test/treiber_stack/stm_treiber_stack.ml
@@ -2,7 +2,7 @@
 
 open QCheck
 open STM
-module Treiber_stack = Lockfree.Treiber_stack
+module Treiber_stack = Saturn.Stack
 
 module TSConf = struct
   type cmd = Push of int | Pop | Is_empty
@@ -60,8 +60,7 @@ let () =
   let count = 500 in
   QCheck_base_runner.run_tests_main
     [
-      TS_seq.agree_test ~count
-        ~name:"STM Lockfree.Treiber_stack test sequential";
+      TS_seq.agree_test ~count ~name:"STM Saturn.Treiber_stack test sequential";
       TS_dom.agree_test_par ~count
-        ~name:"STM Lockfree.Treiber_stack test parallel";
+        ~name:"STM Saturn.Treiber_stack test parallel";
     ]

--- a/test/ws_deque/dune
+++ b/test/ws_deque/dune
@@ -11,17 +11,17 @@
 
 (test
  (name test_ws_deque)
- (libraries lockfree)
+ (libraries saturn)
  (modules test_ws_deque))
 
 (test
  (name qcheck_ws_deque)
- (libraries lockfree qcheck "qcheck-alcotest")
+ (libraries saturn qcheck "qcheck-alcotest")
  (modules qcheck_ws_deque))
 
 (test
  (name stm_ws_deque)
  (modules stm_ws_deque)
- (libraries lockfree qcheck-stm.sequential qcheck-stm.domain)
+ (libraries saturn qcheck-stm.sequential qcheck-stm.domain)
  (action
   (run %{test} --verbose)))

--- a/test/ws_deque/qcheck_ws_deque.ml
+++ b/test/ws_deque/qcheck_ws_deque.ml
@@ -1,4 +1,4 @@
-module Ws_deque = Lockfree.Ws_deque.M
+module Ws_deque = Saturn.Work_stealing_deque.M
 
 (* Sequential building of a deque *)
 let deque_of_list l =

--- a/test/ws_deque/stm_ws_deque.ml
+++ b/test/ws_deque/stm_ws_deque.ml
@@ -3,7 +3,7 @@
 open QCheck
 open STM
 open Util
-module Ws_deque = Lockfree.Ws_deque
+module Ws_deque = Saturn.Work_stealing_deque
 
 module WSDConf = struct
   type cmd = Push of int | Pop | Steal
@@ -78,9 +78,9 @@ let () =
   let count = 1000 in
   QCheck_base_runner.run_tests_main
     [
-      WSDT_seq.agree_test ~count ~name:"STM Lockfree.Ws_deque test sequential";
-      agree_test_par_asym ~count ~name:"STM Lockfree.Ws_deque test parallel";
+      WSDT_seq.agree_test ~count ~name:"STM Saturn.Ws_deque test sequential";
+      agree_test_par_asym ~count ~name:"STM Saturn.Ws_deque test parallel";
       (* Note: this can generate, e.g., pop commands/actions in different threads, thus violating the spec. *)
       WSDT_dom.neg_agree_test_par ~count
-        ~name:"STM Lockfree.Ws_deque test parallel, negative";
+        ~name:"STM Saturn.Ws_deque test parallel, negative";
     ]

--- a/test/ws_deque/test_ws_deque.ml
+++ b/test/ws_deque/test_ws_deque.ml
@@ -1,4 +1,4 @@
-open Lockfree.Ws_deque.M
+open Saturn.Work_stealing_deque.M
 (** Tests *)
 
 let test_empty () =


### PR DESCRIPTION
## TODO list

- [x] Renaming lockfree ->  saturn in all files
- [ ] Renaming the repository 
- [x] Renaming data structures
- [x] Standardize interfaces
- [x] First step toward a better documentation (Using work done in closed PR #55  )

## About this PR
Following a discussion with @bartoszmodelski, @Sudha247 and @polytypic , `lockfree` is going to be renamed and refactored to include domain safe data structures in general and not just lock free ones. 

I wrote down what was discussed previously but everything is still open for discussion.

### Renaming this repository
Several propositions have been made to rename the repository.
- `dsds` or `dssquare` or `dsquare`  or `ds2` for domain safe data structures
- `Saturn`
Any additional opinions about these names are welcomed.

### Renaming current data structures
The data structures are going to be renamed following the example of `Java.utils.concurrent`,

Rules for naming data structures are the following:
1, The implementations that should be used by default are named the simplest way.
2. The others are named according to their limitations or, if it is not enough, from their specific features. 
3. As aliases are easy to use in OCaml, using long but explicit names is alright.


## What is not on this PR (and will be in next-to-come PRs)
- Better README (Including examples)
- Refactoring to 2 packages : a `saturn-lockfree` package with every lockfree data-structures and a `saturn` package that includes lockfree data structures and all other non-composable data structures.
- Another package for composable data structures from `kcas` repository 
- For each current data structures : adding functions with similar semantics than existing one but slightly different types (like `find` and `find_opt`)
- Lock-based data structures
- Benchmarks to compare the different queues
 



