### PR TITLE
Set QCHECK_MSG_INTERVAL to avoid clutter in CI logs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      QCHECK_MSG_INTERVAL: '60'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
QCheck by default prints updates to stdout often to give the user a sense of progress.
This works well in a terminal/console, but less well in an append-only CI-log where the many printed lines adds clutter.
By setting the environment variable `QCHECK_MSG_INTERVAL` to something more sensible, we obtain cleaner CI logs.

(We also use this in `multicoretests` and `domainslib` - but it must have been an oversight in `lockfree`)