### PR TITLE
Mark alcotest as a test dependency

### DIFF
--- a/lockfree.opam
+++ b/lockfree.opam
@@ -15,7 +15,7 @@ depends: [
   "qcheck" {with-test & >= "0.18.1"}
   "qcheck-stm" {with-test & >= "0.1"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
-  "alcotest" {>= "1.6.0"}
+  "alcotest" {with-test & >= "1.6.0"}
   "yojson" {>= "2.0.2"}
   "dscheck" {with-test & >= "0.0.1"}
 ]


### PR DESCRIPTION
from what I could see in the repo, alcotest is only used in tests. So alcotest should be tagged with `with-test` in the opam file.