### PR TITLE
Require qcheck-stm.0.2 and remove pin

### DIFF
--- a/lockfree.opam
+++ b/lockfree.opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "3.0"}
   "domain_shims" {>= "0.1.0"}
   "qcheck" {with-test & >= "0.18.1"}
-  "qcheck-stm" {with-test & >= "0.1.1"}
+  "qcheck-stm" {with-test & >= "0.2"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
   "alcotest" {with-test & >= "1.6.0"}
   "yojson" {>= "2.0.2"}
@@ -22,6 +22,3 @@ depends: [
 available: arch != "x86_32" & arch != "arm32" & arch != "ppc64"
 depopts: []
 build: ["dune" "build" "-p" name "-j" jobs]
-pin-depends: [
-  [ "qcheck-stm.0.1.1"
-    "git+https://github.com/ocaml-multicore/multicoretests.git#4e2e1b22bffec3675a15cf6c2e05f733e9f8b66d" ] ]


### PR DESCRIPTION
This PR removes the qcheck-stm pin now that 0.2 [has been released](https://github.com/ocaml-multicore/multicoretests/releases/tag/0.2).